### PR TITLE
Login error localization to Indonesian, stronger auth error handling, and negative case tests

### DIFF
--- a/__tests__/login/LoginPage.test.tsx
+++ b/__tests__/login/LoginPage.test.tsx
@@ -78,17 +78,22 @@ describe('LoginPage', () => {
     { 
       name: 'network error',
       error: new Error('Network error'),
-      expectedMessage: 'Network error'
+      expectedMessage: 'Tidak dapat terhubung ke server. Silakan periksa koneksi internet Anda.'
     },
     {
       name: 'server error',
       error: new Error('Internal Server Error'),
-      expectedMessage: 'Internal Server Error'
+      expectedMessage: 'Terjadi gangguan pada server. Silakan coba lagi nanti.'
     },
     {
       name: 'unknown error',
       error: 'Unknown error',
       expectedMessage: 'Terjadi kesalahan saat login'
+    },
+    {
+      name: 'invalid credentials',
+      error: new Error('Email atau kata sandi salah.'),
+      expectedMessage: 'Email atau kata sandi salah.'
     }
   ];
   

--- a/__tests__/services/authService.test.ts
+++ b/__tests__/services/authService.test.ts
@@ -1,0 +1,77 @@
+import { authService } from '../../services/authService';
+import { LoginRequestBody } from '../../types';
+
+describe('authService.login error handling', () => {
+  const originalFetch = global.fetch;
+  const credentials: LoginRequestBody = { email: 'user@example.com', password: 'secret' };
+
+  const mockErrorResponse = (status: number, detail: unknown) => ({
+    ok: false,
+    status,
+    json: jest.fn().mockResolvedValue(detail),
+  }) as unknown as Response;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
+    process.env.NEXT_PUBLIC_API_KEY = 'test-key';
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('returns Indonesian message when credentials are invalid (401)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockErrorResponse(401, { detail: 'Invalid credentials' }),
+    );
+
+    await expect(authService.login(credentials)).rejects.toThrow('Email atau kata sandi salah.');
+  });
+
+  it('returns Indonesian message when account is not found (404)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockErrorResponse(404, { detail: 'User not found' }),
+    );
+
+    await expect(authService.login(credentials)).rejects.toThrow('Akun tidak ditemukan.');
+  });
+
+  it('returns Indonesian message when access is forbidden (403)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockErrorResponse(403, { detail: 'Account inactive' }),
+    );
+
+    await expect(authService.login(credentials)).rejects.toThrow('Akses login ditolak. Hubungi administrator Anda.');
+  });
+
+  it('returns Indonesian message when rate limited (429)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockErrorResponse(429, { detail: 'Too many attempts' }),
+    );
+
+    await expect(authService.login(credentials)).rejects.toThrow('Terlalu banyak percobaan login. Silakan coba lagi beberapa menit lagi.');
+  });
+
+  it('handles validation errors with array detail (400)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockErrorResponse(400, { detail: ['Email is required'] }),
+    );
+
+    await expect(authService.login(credentials)).rejects.toThrow('Data login tidak valid. Periksa kembali email dan kata sandi Anda.');
+  });
+
+  it('falls back to server error message when JSON parsers fail', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: jest.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
+    });
+
+    await expect(authService.login(credentials)).rejects.toThrow('Terjadi gangguan pada server. Silakan coba lagi nanti.');
+  });
+});

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -29,16 +29,24 @@ function LoginForm() {
       try {
         const credentials: LoginRequestBody = { email, password };
         await login(credentials);
-        console.log('Login successful!');
         router.push('/');
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : 'Terjadi kesalahan saat login');
+        if (err instanceof Error) {
+          const normalized = err.message.toLowerCase();
+          if (normalized.includes('network') || normalized.includes('fetch')) {
+            setError('Tidak dapat terhubung ke server. Silakan periksa koneksi internet Anda.');
+          } else if (normalized.includes('server')) {
+            setError('Terjadi gangguan pada server. Silakan coba lagi nanti.');
+          } else {
+            setError(err.message || 'Terjadi kesalahan saat login');
+          }
+        } else {
+          setError('Terjadi kesalahan saat login');
+        }
       } finally {
         setLoading(false);
       }
     };
-    console.log('User from Login:', user);
-
     return (
       <div className="flex flex-col md:flex-row items-center justify-center bg-white px-4 sm:mx-6 my-8 sm:my-12">
         <div className="w-full md:w-1/2 lg:w-2/5 mb-6 md:mb-0 md:mr-8 lg:mr-16 flex justify-center">

--- a/services/authService.ts
+++ b/services/authService.ts
@@ -11,21 +11,72 @@ export interface RegisterData {
 
 // Helper function to handle API error responses
 const handleApiError = async (response: Response, defaultMessage: string) => {
-  const errorData = await response.json();
-  let errorMessage = defaultMessage;
-  
-  if (errorData.detail) {
-    if (Array.isArray(errorData.detail)) {
-      // Get the first error message and clean it
-      const rawMessage = errorData.detail[0];
-      // Remove all special characters and quotes
-      errorMessage = rawMessage.replace(/[[\]'"]/g, '');
-    } else if (typeof errorData.detail === 'string') {
-      errorMessage = errorData.detail;
-    }
+  let detail: unknown;
+  try {
+    const errorData = await response.json();
+    detail = errorData?.detail ?? errorData?.message;
+  } catch {
+    detail = undefined;
   }
-  
-  throw new Error(errorMessage);
+
+  const extractDetail = (): string | undefined => {
+    if (!detail) return undefined;
+    if (typeof detail === 'string') return detail;
+    if (Array.isArray(detail) && detail.length > 0) {
+      return String(detail[0]).replace(/[[\]'\"]/g, '');
+    }
+    if (typeof detail === 'object') {
+      const values = Object.values(detail as Record<string, unknown>);
+      if (values.length > 0) {
+        return String(values[0]);
+      }
+    }
+    return undefined;
+  };
+
+  const detailMessage = extractDetail();
+  const normalizedDetail = detailMessage?.toLowerCase() ?? '';
+  const status = response.status;
+  const isLoginContext = defaultMessage.toLowerCase().includes('masuk');
+
+  const pickMessage = (): string => {
+    if (
+      status === 401 ||
+      normalizedDetail.includes('unauthorized') ||
+      normalizedDetail.includes('invalid credentials') ||
+      normalizedDetail.includes('wrong password')
+    ) {
+      return isLoginContext ? 'Email atau kata sandi salah.' : 'Akses ditolak. Hubungi administrator Anda.';
+    }
+
+    if (status === 404 || normalizedDetail.includes('not found')) {
+      return isLoginContext ? 'Akun tidak ditemukan.' : 'Data tidak ditemukan.';
+    }
+
+    if (status === 403 || normalizedDetail.includes('inactive') || normalizedDetail.includes('forbidden')) {
+      return isLoginContext ? 'Akses login ditolak. Hubungi administrator Anda.' : 'Akses ditolak. Hubungi administrator Anda.';
+    }
+
+    if (status === 429 || normalizedDetail.includes('too many')) {
+      return isLoginContext
+        ? 'Terlalu banyak percobaan login. Silakan coba lagi beberapa menit lagi.'
+        : 'Terlalu banyak permintaan. Silakan coba lagi nanti.';
+    }
+
+    if (status === 400 || status === 422 || normalizedDetail.includes('validation')) {
+      return isLoginContext
+        ? 'Data login tidak valid. Periksa kembali email dan kata sandi Anda.'
+        : 'Data yang Anda kirimkan tidak valid. Silakan periksa kembali.';
+    }
+
+    if (status >= 500) {
+      return 'Terjadi gangguan pada server. Silakan coba lagi nanti.';
+    }
+
+    return detailMessage ?? defaultMessage;
+  };
+
+  throw new Error(pickMessage());
 };
 
 export const authService = {
@@ -40,7 +91,7 @@ export const authService = {
     });
 
     if (!response.ok) {
-      return handleApiError(response, 'Terjadi kesalahan saat mendaftar');
+  return handleApiError(response, 'Terjadi kesalahan saat mendaftar');
     }
 
     return response.json();
@@ -59,7 +110,7 @@ export const authService = {
     });
 
     if (!response.ok) {
-      return handleApiError(response, 'Terjadi kesalahan saat masuk');
+  return handleApiError(response, 'Terjadi kesalahan saat masuk');
     }
     return response.json();
   }


### PR DESCRIPTION
Overview
This PR makes login failures friendlier for users in Indonesia and hardens our error mapping. It also adds thorough negative case tests for both the login page and authService.

What changed
	•	authService.handleApiError now safely parses API errors and maps HTTP status and common detail strings to clear Indonesian messages.
	•	401 → “Email atau kata sandi salah.”
	•	404 → “Akun tidak ditemukan.”
	•	403 → “Akses login ditolak. Hubungi administrator Anda.”
	•	429 → “Terlalu banyak percobaan login. Silakan coba lagi beberapa menit lagi.”
	•	400 or 422 → “Data login tidak valid. Periksa kembali email dan kata sandi Anda.”
	•	500+ → “Terjadi gangguan pada server. Silakan coba lagi nanti.”
	•	Fallback keeps the server message when safe.
	•	app/login/page.tsx normalizes network and server errors so users get helpful Indonesian copy instead of raw exceptions.
	•	New tests:
	•	__tests__/services/authService.test.ts covers 401, 404, 403, 429, 400 array detail, and JSON parse failure on 500.
	•	__tests__/login/LoginPage.test.tsx covers localized messages for network, server, unknown error, and invalid credentials.
	•	Minor test harness tweaks for env vars and fetch mocking.

Why
	•	Consistent Indonesian UX during auth flows.
	•	Less confusion for users when the problem is network, credentials, or the server.
	•	Higher confidence with targeted negative case coverage.

How to test
	1.	pnpm install
	2.	pnpm test and confirm new suites pass.
	3.	pnpm dev, open /login, try:
	•	Turn on network offline in DevTools and submit → “Tidak dapat terhubung ke server…”
	•	Point API to a stub that returns 401 → “Email atau kata sandi salah.”
	•	Return 404 → “Akun tidak ditemukan.”
	•	Return 403 → “Akses login ditolak…”
	•	Return 429 → “Terlalu banyak percobaan login…”
	•	Return 500 or break JSON → “Terjadi gangguan pada server…”

Impact
	•	No API contract changes.
	•	User-visible copy changes on login failures.
	•	Frontend only.

Risks and rollback
	•	Low risk. If anything feels off, revert this PR or swap messages back to previous defaults.

Housekeeping
	•	Tests added and passing
	•	Indonesian copy reviewed
	•	Link issue if applicable for tracking (Closes #<issue-number>)