### PR TITLE
Pbi 6 data visualization download

### DIFF
--- a/__tests__/dashboard/DownloadButton.test.tsx
+++ b/__tests__/dashboard/DownloadButton.test.tsx
@@ -12,8 +12,15 @@ const { exportElementAsPng } = jest.requireMock("@/utils/exportAsImage") as {
 };
 
 describe("DownloadButton", () => {
+  let alertSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
   });
 
   it("exports the provided element as PNG", async () => {
@@ -47,6 +54,10 @@ describe("DownloadButton", () => {
     expect(appendedAnchor?.download).toBe("sample.png");
     expect(appendedAnchor?.href).toBe("data:image/png;base64,AAA");
 
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("Berhasil mengunduh visualisasi.");
+    });
+
     appendSpy.mockRestore();
   });
 
@@ -65,7 +76,26 @@ describe("DownloadButton", () => {
 
     expect(exportElementAsPng).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith("Gagal mengunduh visualisasi.");
 
     warnSpy.mockRestore();
+  });
+
+  it("shows empty data message when canDownload returns false", () => {
+    const target = document.createElement("div");
+
+    render(
+      <DownloadButton
+        filename="empty"
+        getTarget={() => target}
+        canDownload={() => false}
+        label="Unduh Kosong"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /unduh kosong/i }));
+
+    expect(exportElementAsPng).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith("Gagal mengunduh: data kosong.");
   });
 });

--- a/app/components/dashboard/CasesLevel.tsx
+++ b/app/components/dashboard/CasesLevel.tsx
@@ -20,6 +20,11 @@ interface AmChartTingkatanKasusProps {
 export default function AmChartTingkatanKasus ({ jsonData }: Readonly<AmChartTingkatanKasusProps>) {
   const chartRef = useRef(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasData =
+    !!jsonData?.data &&
+    Object.values(jsonData.data).some(
+      (entries) => Array.isArray(entries) && entries.some((item) => item.count > 0)
+    );
 
   useEffect(() => {
     if (!jsonData?.data || !chartRef.current) return;
@@ -183,6 +188,7 @@ export default function AmChartTingkatanKasus ({ jsonData }: Readonly<AmChartTin
           <DownloadButton
             filename="tingkatan-kasus"
             getTarget={() => containerRef.current}
+            canDownload={() => hasData}
           />
           <div id="dataCount" className="text-xl font-semibold text-[#0069CF]"></div> {/* Reduced font size */}
         </div>

--- a/app/components/dashboard/DownloadButton.tsx
+++ b/app/components/dashboard/DownloadButton.tsx
@@ -7,9 +7,13 @@ import { exportElementAsPng } from "@/utils/exportAsImage";
 interface DownloadButtonProps {
   filename: string;
   getTarget: () => HTMLElement | null;
+  canDownload?: () => boolean;
   label?: string;
   className?: string;
   size?: "sm" | "md";
+  successMessage?: string;
+  emptyMessage?: string;
+  errorMessage?: string;
 }
 
 const baseClasses =
@@ -26,9 +30,13 @@ const ensurePngExtension = (filename: string) =>
 const DownloadButton: React.FC<DownloadButtonProps> = ({
   filename,
   getTarget,
+  canDownload,
   label = "Unduh Gambar",
   className,
-  size = "sm"
+  size = "sm",
+  successMessage = "Berhasil mengunduh visualisasi.",
+  emptyMessage = "Gagal mengunduh: data kosong.",
+  errorMessage = "Gagal mengunduh visualisasi."
 }) => {
   const [isExporting, setIsExporting] = useState(false);
 
@@ -38,6 +46,12 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({
     const target = getTarget();
     if (!target) {
       console.warn(`No element available for download: ${filename}`);
+      window.alert(errorMessage);
+      return;
+    }
+
+    if (canDownload && !canDownload()) {
+      window.alert(emptyMessage);
       return;
     }
 
@@ -51,8 +65,10 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({
       document.body.appendChild(link);
       link.click();
       link.remove();
+      window.alert(successMessage);
     } catch (error) {
       console.error(`Failed to export ${filename} as image`, error);
+      window.alert(errorMessage);
     } finally {
       setIsExporting(false);
     }

--- a/app/components/dashboard/PrevalenceCard.tsx
+++ b/app/components/dashboard/PrevalenceCard.tsx
@@ -13,6 +13,9 @@ const PrevalenceCard: React.FC<PrevalenceCardProps> = ({
   populationCount,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasData =
+    (typeof prevalenceRate === "number" && prevalenceRate > 0) ||
+    (typeof populationCount === "number" && populationCount > 0);
   // Format the population number with commas
   let formattedPopulation = null
   /* istanbul ignore else */
@@ -31,6 +34,7 @@ const PrevalenceCard: React.FC<PrevalenceCardProps> = ({
         <DownloadButton
           filename="estimasi-prevalensi"
           getTarget={() => containerRef.current}
+          canDownload={() => hasData}
         />
       </div>
       

--- a/app/components/dashboard/age_statistic/AgeStatisticCard.tsx
+++ b/app/components/dashboard/age_statistic/AgeStatisticCard.tsx
@@ -146,6 +146,7 @@ export default function AgeStatisticCard({ data }: Readonly<AgeStatisticCardProp
           <DownloadButton
             filename="distribusi-usia"
             getTarget={() => containerRef.current}
+            canDownload={() => totalCases > 0}
           />
           <div className="flex items-center text-[#0069CF] text-xl font-bold">
             <PeopleIcon className="w-6 h-6 mr-2" />

--- a/app/components/dashboard/cases_number/CaseNumberCard.tsx
+++ b/app/components/dashboard/cases_number/CaseNumberCard.tsx
@@ -12,6 +12,11 @@ interface CaseNumbersProps {
   
 const CaseNumberCard:  React.FC<CaseNumbersProps> = ({ jumlah_kasus, jumlah_kasus_kematian, jumlah_kasus_terjangkit, jumlah_kasus_sembuh }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const hasData =
+    Number(jumlah_kasus) > 0 ||
+    Number(jumlah_kasus_kematian) > 0 ||
+    Number(jumlah_kasus_terjangkit) > 0 ||
+    Number(jumlah_kasus_sembuh) > 0;
   return (
     <div ref={containerRef} className="w-full mx-auto bg-white rounded-lg shadow p-4">
       <div className="flex flex-wrap justify-between items-center gap-3">
@@ -20,6 +25,7 @@ const CaseNumberCard:  React.FC<CaseNumbersProps> = ({ jumlah_kasus, jumlah_kasu
           <DownloadButton
             filename="jumlah-kasus"
             getTarget={() => containerRef.current}
+            canDownload={() => hasData}
           />
           <div className="flex items-center text-[#0069CF] text-xl font-bold">
             <PeopleIcon className="w-6 h-6 mr-2" />

--- a/app/components/dashboard/gender_distribution/GenderDonutChart.tsx
+++ b/app/components/dashboard/gender_distribution/GenderDonutChart.tsx
@@ -14,6 +14,9 @@ interface GenderDonutChartProps {
 const GenderDonutChart: React.FC<GenderDonutChartProps> = ({ total, priaValue, wanitaValue }) => {
   const chartRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const totalCount =
+    (typeof total === "number" ? total : 0) ||
+    (priaValue ?? 0) + (wanitaValue ?? 0);
   
   // Initialize the chart using our custom hook
   useDonutChart(chartRef, priaValue ?? 0, wanitaValue ?? 0);
@@ -28,6 +31,7 @@ const GenderDonutChart: React.FC<GenderDonutChartProps> = ({ total, priaValue, w
             <DownloadButton
               filename="distribusi-jenis-kelamin"
               getTarget={() => containerRef.current}
+              canDownload={() => totalCount > 0}
             />
           }
         />

--- a/app/components/dashboard/sumberBerita/PortalBarChart.tsx
+++ b/app/components/dashboard/sumberBerita/PortalBarChart.tsx
@@ -296,6 +296,7 @@ const PortalBarChart: React.FC<PortalBarChartProps> = ({
           <DownloadButton
             filename={downloadFilename}
             getTarget={() => containerRef.current}
+            canDownload={() => data.length > 0}
           />
           <button 
             className="bg-[#0069CF] text-white text-sm py-2 px-4 rounded-[10px] flex items-center font-medium"

--- a/app/components/severity/Severity.tsx
+++ b/app/components/severity/Severity.tsx
@@ -277,6 +277,11 @@ const SeverityChart = ({
     }));
   }, [rawData]);
 
+  const hasData = useMemo(
+    () => transformedData.some(item => item.total_cases > 0),
+    [transformedData]
+  );
+
   const loadData = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -410,6 +415,7 @@ const SeverityChart = ({
           <DownloadButton
             filename={title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}
             getTarget={() => containerRef.current}
+            canDownload={() => hasData}
           />
           <div className="flex gap-3 items-center flex-wrap">
             {seriesConfig.map((config) => (


### PR DESCRIPTION
This pull request adds clear user feedback for downloading dashboard visuals and guards against exporting empty charts, delivered with a small RED then GREEN cycle. I introduced an optional canDownload check and new optional messages on DownloadButton so it can show a success message, an empty data message, or an error message, with safe defaults. I wired canDownload into the cards and charts so we only export when there is real data, including CasesLevel, PrevalenceCard, AgeStatisticCard, CaseNumberCard, GenderDonutChart, PortalBarChart, and Severity. The export flow keeps the correct .png filename and cleans up the temporary link. Tests now verify three paths: successful export shows “Berhasil mengunduh visualisasi.”, empty data shows “Gagal mengunduh: data kosong.” without calling the exporter, and missing target or failure shows “Gagal mengunduh visualisasi.”. This improves UX by replacing silent failures with honest messages and follows our empty state contract. It is backward compatible because all new props are optional and defaults are provided. To verify manually, try downloading from a card with data and see the PNG and success alert, then try a zero-data card and see the empty data alert with no file, and finally simulate a missing element to see the error alert. Next steps can include replacing window alerts with our toast component, adding i18n keys, and adding an end to end test for happy and empty paths.