### PR TITLE
Pbi 10 expert data visualization download

### DIFF
--- a/__tests__/expert-dashboard/ExpertDashboardPage.test.tsx
+++ b/__tests__/expert-dashboard/ExpertDashboardPage.test.tsx
@@ -39,10 +39,7 @@ describe("ExpertDashboardPage", () => {
       screen.getByLabelText(trendLabel, { selector: "input[type='radio']" })
     ).toBeChecked();
     expect(
-      screen.getByRole("heading", {
-        name: "Trend Mode – Weekly Cases",
-        level: 3,
-      })
+      screen.getByText("Trend Mode - Weekly Cases")
     ).toBeInTheDocument();
   });
 
@@ -64,10 +61,7 @@ describe("ExpertDashboardPage", () => {
       screen.getByText(CHART_MODE_METADATA[storedMode].description)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", {
-        name: "Grouped Totals – Cases by Category",
-        level: 3,
-      })
+      screen.getByText("Grouped Totals - Cases by Category")
     ).toBeInTheDocument();
   });
 
@@ -88,10 +82,7 @@ describe("ExpertDashboardPage", () => {
       "grouped_totals"
     );
     expect(
-      screen.getByRole("heading", {
-        name: "Grouped Totals – Cases by Category",
-        level: 3,
-      })
+      screen.getByText("Grouped Totals - Cases by Category")
     ).toBeInTheDocument();
   });
 });

--- a/__tests__/expert-dashboard/TooltipContent.test.tsx
+++ b/__tests__/expert-dashboard/TooltipContent.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import TooltipContent from "../../app/expert-dashboard/components/TooltipContent";
+import { expertDashboardFlags } from "../../app/expert-dashboard/tooltip";
+
+describe("TooltipContent", () => {
+  afterEach(() => {
+    expertDashboardFlags.showReferenceDelta = true;
+  });
+
+  it("renders value, reference and change with percentage", () => {
+    render(
+      <TooltipContent
+        datum={{ label: "Kasus", value: 120, reference: 100 }}
+      />
+    );
+
+    expect(screen.getByTestId("tooltip-label")).toHaveTextContent("Kasus");
+    expect(screen.getByTestId("tooltip-value")).toHaveTextContent(
+      "Value: 120"
+    );
+    expect(
+      screen.getByTestId("tooltip-reference")
+    ).toHaveTextContent("Reference: 100");
+    expect(screen.getByTestId("tooltip-change")).toHaveTextContent(
+      "Change: +20 (+20%)"
+    );
+  });
+
+  it("renders change without percentage when reference is zero", () => {
+    render(
+      <TooltipContent
+        datum={{ label: "Kasus", value: 45, reference: 0 }}
+      />
+    );
+
+    expect(screen.getByTestId("tooltip-change")).toHaveTextContent(
+      "Change: +45"
+    );
+  });
+
+  it("renders only value when reference absent", () => {
+    render(<TooltipContent datum={{ label: "Kasus", value: 75 }} />);
+
+    expect(screen.queryByTestId("tooltip-reference")).toBeNull();
+    expect(screen.queryByTestId("tooltip-change")).toBeNull();
+    expect(screen.getByTestId("tooltip-value")).toHaveTextContent(
+      "Value: 75"
+    );
+  });
+
+  it("hides change when feature flag disabled", () => {
+    expertDashboardFlags.showReferenceDelta = false;
+
+    render(
+      <TooltipContent
+        datum={{ label: "Kasus", value: 80, reference: 60 }}
+      />
+    );
+
+    expect(screen.queryByTestId("tooltip-change")).toBeNull();
+  });
+});

--- a/__tests__/expert-dashboard/tooltip.test.ts
+++ b/__tests__/expert-dashboard/tooltip.test.ts
@@ -1,0 +1,99 @@
+import {
+  computeDelta,
+  expertDashboardFlags,
+  formatTooltipLines,
+  mapToTooltipDatum,
+} from "../../app/expert-dashboard/tooltip";
+
+describe("expert-dashboard tooltip helpers", () => {
+  afterEach(() => {
+    expertDashboardFlags.showReferenceDelta = true;
+  });
+
+  it("computes positive delta with percentage", () => {
+    const result = computeDelta(120, 100);
+    expect(result).toEqual({ delta: 20, pct: 20 });
+  });
+
+  it("computes negative delta with percentage", () => {
+    const result = computeDelta(80, 100);
+    expect(result).toEqual({ delta: -20, pct: -20 });
+  });
+
+  it("returns null percentage when reference is zero", () => {
+    const result = computeDelta(50, 0);
+    expect(result).toEqual({ delta: 50, pct: null });
+  });
+
+  it("returns null delta when reference missing", () => {
+    const result = computeDelta(50, undefined);
+    expect(result).toEqual({ delta: null, pct: null });
+  });
+
+  it("maps raw datum fields to TooltipDatum structure", () => {
+    const raw = {
+      count: "42",
+      previous: 40,
+      name: "Hospitalisasi",
+      period: "2024-W01",
+    };
+
+    const datum = mapToTooltipDatum(raw);
+    expect(datum).toEqual({
+      value: 42,
+      reference: 40,
+      label: "Hospitalisasi",
+      timestamp: "2024-W01",
+    });
+  });
+
+  it("formats tooltip lines with value, reference, delta and percent", () => {
+    const lines = formatTooltipLines({
+      value: 120,
+      reference: 100,
+      label: "Kasus",
+    });
+    expect(lines).toEqual([
+      "Kasus",
+      "Value: 120",
+      "Reference: 100",
+      "Change: +20 (+20%)",
+    ]);
+  });
+
+  it("omits percentage when reference is zero", () => {
+    const lines = formatTooltipLines({
+      value: 45,
+      reference: 0,
+      label: "Kasus",
+    });
+    expect(lines).toEqual([
+      "Kasus",
+      "Value: 45",
+      "Reference: 0",
+      "Change: +45",
+    ]);
+  });
+
+  it("skips change lines when reference absent", () => {
+    const lines = formatTooltipLines({
+      value: 75,
+      label: "Kasus",
+    });
+    expect(lines).toEqual(["Kasus", "Value: 75"]);
+  });
+
+  it("respects feature flag to hide delta", () => {
+    expertDashboardFlags.showReferenceDelta = false;
+    const lines = formatTooltipLines({
+      value: 60,
+      reference: 50,
+      label: "Kasus",
+    });
+    expect(lines).toEqual([
+      "Kasus",
+      "Value: 60",
+      "Reference: 50",
+    ]);
+  });
+});

--- a/app/components/dashboard/sumberBerita/PortalBarChart.tsx
+++ b/app/components/dashboard/sumberBerita/PortalBarChart.tsx
@@ -7,6 +7,7 @@ import DownloadButton from "../DownloadButton";
 interface PortalData {
   portal: string;
   count: number;
+  tooltipText?: string;
 }
 
 interface PortalBarChartProps {
@@ -28,7 +29,8 @@ const prepareChartData = (data: PortalData[], colors: string[], am5: any) => {
   return data.map((item, idx) => ({
     source: item.portal,
     value: item.count,
-    color: getItemColor(idx, colors, am5)
+    color: getItemColor(idx, colors, am5),
+    tooltipText: item.tooltipText,
   }));
 };
 
@@ -224,7 +226,10 @@ const PortalBarChart: React.FC<PortalBarChartProps> = ({
           series.get("tooltip").label.setAll({
             fontSize: 12,
             fontWeight: "400",
-            fill: am5.color("#333333")
+            fill: am5.color("#333333"),
+            lineHeight: 1.4,
+            textAlign: "left",
+            multiLine: true,
           });
         }
 
@@ -251,6 +256,14 @@ const PortalBarChart: React.FC<PortalBarChartProps> = ({
           strokeOpacity: 0,
           strokeWidth: 0, 
           stroke: null
+        });
+
+        series.columns.template.adapters.add("tooltipText", (text: string | undefined, target: any) => {
+          const custom = target?.dataItem?.dataContext?.tooltipText;
+          if (typeof custom === "string" && custom.trim().length > 0) {
+            return custom;
+          }
+          return text;
         });
 
         // Prepare series data using the utility function

--- a/app/expert-dashboard/ChartRenderer.tsx
+++ b/app/expert-dashboard/ChartRenderer.tsx
@@ -2,40 +2,47 @@
 
 import PortalBarChart from "../components/dashboard/sumberBerita/PortalBarChart";
 import type { ChartMode } from "./chartModePreference";
+import {
+  formatTooltipLines,
+  mapToTooltipDatum,
+  type TooltipDatum,
+} from "./tooltip";
+
+type ExpertDatum = TooltipDatum & { label: string };
 
 type ChartDefinition = Readonly<{
   title: string;
-  data: Array<{ portal: string; count: number }>;
+  data: ExpertDatum[];
 }>;
 
 const CHART_DEFINITIONS: Record<ChartMode, ChartDefinition> = {
   trend: {
-    title: "Trend Mode – Weekly Cases",
+    title: "Trend Mode - Weekly Cases",
     data: [
-      { portal: "Minggu 1", count: 12 },
-      { portal: "Minggu 2", count: 18 },
-      { portal: "Minggu 3", count: 21 },
-      { portal: "Minggu 4", count: 26 },
-      { portal: "Minggu 5", count: 30 },
+      { label: "Minggu 1", value: 12, reference: 10 },
+      { label: "Minggu 2", value: 18, reference: 16 },
+      { label: "Minggu 3", value: 21, reference: 19 },
+      { label: "Minggu 4", value: 26, reference: 24 },
+      { label: "Minggu 5", value: 30, reference: 28 },
     ],
   },
   grouped_totals: {
-    title: "Grouped Totals – Cases by Category",
+    title: "Grouped Totals - Cases by Category",
     data: [
-      { portal: "Hospitalisasi", count: 42 },
-      { portal: "Isolasi", count: 55 },
-      { portal: "Rawat Jalan", count: 31 },
-      { portal: "Monitoring", count: 24 },
+      { label: "Hospitalisasi", value: 42, reference: 40 },
+      { label: "Isolasi", value: 55, reference: 50 },
+      { label: "Rawat Jalan", value: 31, reference: 34 },
+      { label: "Monitoring", value: 24, reference: 20 },
     ],
   },
   raw_chart: {
-    title: "Raw Chart – Daily Submissions",
+    title: "Raw Chart - Daily Submissions",
     data: [
-      { portal: "Senin", count: 14 },
-      { portal: "Selasa", count: 17 },
-      { portal: "Rabu", count: 19 },
-      { portal: "Kamis", count: 16 },
-      { portal: "Jumat", count: 18 },
+      { label: "Senin", value: 14, reference: 13 },
+      { label: "Selasa", value: 17, reference: 18 },
+      { label: "Rabu", value: 19, reference: 19 },
+      { label: "Kamis", value: 16 },
+      { label: "Jumat", value: 18, reference: 0 },
     ],
   },
 };
@@ -47,9 +54,26 @@ type ChartRendererProps = Readonly<{
 export default function ChartRenderer({ mode }: ChartRendererProps) {
   const chart = CHART_DEFINITIONS[mode] ?? CHART_DEFINITIONS.trend;
 
+  const data = chart.data.map((datum) => {
+    const raw = {
+      ...datum,
+      portal: datum.label,
+      count: datum.value,
+    } as Record<string, unknown>;
+
+    const tooltipDatum = mapToTooltipDatum(raw);
+    const tooltipLines = formatTooltipLines(tooltipDatum);
+
+    return {
+      portal: datum.label,
+      count: datum.value,
+      tooltipText: tooltipLines.join("\n"),
+    };
+  });
+
   return (
     <div className="space-y-3" data-testid={`expert-chart-${mode}`}>
-      <PortalBarChart title={chart.title} data={chart.data} index={0} />
+      <PortalBarChart title={chart.title} data={data} index={0} />
     </div>
   );
 }

--- a/app/expert-dashboard/ChartRenderer.tsx
+++ b/app/expert-dashboard/ChartRenderer.tsx
@@ -2,78 +2,37 @@
 
 import PortalBarChart from "../components/dashboard/sumberBerita/PortalBarChart";
 import type { ChartMode } from "./chartModePreference";
-import {
-  formatTooltipLines,
-  mapToTooltipDatum,
-  type TooltipDatum,
-} from "./tooltip";
-
-type ExpertDatum = TooltipDatum & { label: string };
-
-type ChartDefinition = Readonly<{
-  title: string;
-  data: ExpertDatum[];
-}>;
-
-const CHART_DEFINITIONS: Record<ChartMode, ChartDefinition> = {
-  trend: {
-    title: "Trend Mode - Weekly Cases",
-    data: [
-      { label: "Minggu 1", value: 12, reference: 10 },
-      { label: "Minggu 2", value: 18, reference: 16 },
-      { label: "Minggu 3", value: 21, reference: 19 },
-      { label: "Minggu 4", value: 26, reference: 24 },
-      { label: "Minggu 5", value: 30, reference: 28 },
-    ],
-  },
-  grouped_totals: {
-    title: "Grouped Totals - Cases by Category",
-    data: [
-      { label: "Hospitalisasi", value: 42, reference: 40 },
-      { label: "Isolasi", value: 55, reference: 50 },
-      { label: "Rawat Jalan", value: 31, reference: 34 },
-      { label: "Monitoring", value: 24, reference: 20 },
-    ],
-  },
-  raw_chart: {
-    title: "Raw Chart - Daily Submissions",
-    data: [
-      { label: "Senin", value: 14, reference: 13 },
-      { label: "Selasa", value: 17, reference: 18 },
-      { label: "Rabu", value: 19, reference: 19 },
-      { label: "Kamis", value: 16 },
-      { label: "Jumat", value: 18, reference: 0 },
-    ],
-  },
-};
+import { getChartModeStrategy } from "./chartModeStrategies";
+import { formatTooltipLines, mapToTooltipDatum } from "./tooltip";
 
 type ChartRendererProps = Readonly<{
   mode: ChartMode;
 }>;
 
 export default function ChartRenderer({ mode }: ChartRendererProps) {
-  const chart = CHART_DEFINITIONS[mode] ?? CHART_DEFINITIONS.trend;
+  const strategy = getChartModeStrategy(mode);
+  const points = strategy.buildPoints();
 
-  const data = chart.data.map((datum) => {
+  const data = points.map((point) => {
     const raw = {
-      ...datum,
-      portal: datum.label,
-      count: datum.value,
+      ...point,
+      portal: point.label,
+      count: point.value,
     } as Record<string, unknown>;
 
     const tooltipDatum = mapToTooltipDatum(raw);
     const tooltipLines = formatTooltipLines(tooltipDatum);
 
     return {
-      portal: datum.label,
-      count: datum.value,
+      portal: point.label,
+      count: point.value,
       tooltipText: tooltipLines.join("\n"),
     };
   });
 
   return (
     <div className="space-y-3" data-testid={`expert-chart-${mode}`}>
-      <PortalBarChart title={chart.title} data={data} index={0} />
+      <PortalBarChart title={strategy.title} data={data} index={0} />
     </div>
   );
 }

--- a/app/expert-dashboard/chartModeStrategies.ts
+++ b/app/expert-dashboard/chartModeStrategies.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ChartMode } from "./chartModePreference";
+import type { TooltipDatum } from "./tooltip";
+
+/**
+ * Strategy pattern: encapsulates chart-mode specific datasets so ChartRenderer
+ * stays agnostic of how each mode prepares its points or metadata.
+ */
+export type ExpertChartPoint = TooltipDatum & {
+  label: string;
+};
+
+interface ChartModeStrategy {
+  readonly title: string;
+  buildPoints(): ExpertChartPoint[];
+}
+
+const trendStrategy: ChartModeStrategy = {
+  title: "Trend Mode - Weekly Cases",
+  buildPoints: () => [
+    { label: "Minggu 1", value: 12, reference: 10 },
+    { label: "Minggu 2", value: 18, reference: 16 },
+    { label: "Minggu 3", value: 21, reference: 19 },
+    { label: "Minggu 4", value: 26, reference: 24 },
+    { label: "Minggu 5", value: 30, reference: 28 },
+  ],
+};
+
+const groupedTotalsStrategy: ChartModeStrategy = {
+  title: "Grouped Totals - Cases by Category",
+  buildPoints: () => [
+    { label: "Hospitalisasi", value: 42, reference: 40 },
+    { label: "Isolasi", value: 55, reference: 50 },
+    { label: "Rawat Jalan", value: 31, reference: 34 },
+    { label: "Monitoring", value: 24, reference: 20 },
+  ],
+};
+
+const rawChartStrategy: ChartModeStrategy = {
+  title: "Raw Chart - Daily Submissions",
+  buildPoints: () => [
+    { label: "Senin", value: 14, reference: 13 },
+    { label: "Selasa", value: 17, reference: 18 },
+    { label: "Rabu", value: 19, reference: 19 },
+    { label: "Kamis", value: 16 },
+    { label: "Jumat", value: 18, reference: 0 },
+  ],
+};
+
+const STRATEGIES: Record<ChartMode, ChartModeStrategy> = {
+  trend: trendStrategy,
+  grouped_totals: groupedTotalsStrategy,
+  raw_chart: rawChartStrategy,
+};
+
+export const getChartModeStrategy = (mode: ChartMode): ChartModeStrategy =>
+  STRATEGIES[mode] ?? trendStrategy;

--- a/app/expert-dashboard/components/TooltipContent.tsx
+++ b/app/expert-dashboard/components/TooltipContent.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import clsx from "clsx";
+import {
+  TooltipDatum,
+  computeDelta,
+  expertDashboardFlags,
+  formatNumber,
+  formatPercent,
+} from "../tooltip";
+
+type TooltipContentProps = Readonly<{
+  datum: TooltipDatum;
+  className?: string;
+}>;
+
+const wrapperClasses =
+  "rounded-md border border-slate-200 bg-white px-3 py-2 shadow";
+const labelClasses = "text-xs font-semibold text-slate-600";
+const valueClasses = "text-sm font-medium text-slate-900";
+const metaClasses = "text-xs text-slate-500";
+
+const formatSigned = (value: number): string => {
+  const absolute = Math.abs(value);
+  const formatted = formatNumber(absolute);
+  if (value > 0) return `+${formatted}`;
+  if (value < 0) return `-${formatted}`;
+  return formatted;
+};
+
+const formatSignedPercent = (value: number): string => {
+  const absolute = Math.abs(value);
+  const formatted = formatPercent(absolute);
+  if (value > 0) return `+${formatted}`;
+  if (value < 0) return `-${formatted}`;
+  return formatted;
+};
+
+export default function TooltipContent({
+  datum,
+  className = "",
+}: TooltipContentProps) {
+  const referenceProvided =
+    datum.reference !== null && datum.reference !== undefined;
+  const delta = computeDelta(datum.value, datum.reference);
+  const shouldRenderDelta =
+    referenceProvided &&
+    delta.delta !== null &&
+    expertDashboardFlags.showReferenceDelta;
+
+  return (
+    <div className={clsx(wrapperClasses, className)} data-testid="expert-tooltip">
+      <div className="flex flex-col gap-1">
+        {datum.label ? (
+          <div className={labelClasses} data-testid="tooltip-label">
+            {datum.label}
+          </div>
+        ) : null}
+        {datum.timestamp !== undefined && datum.timestamp !== null ? (
+          <div className={metaClasses} data-testid="tooltip-timestamp">
+            {String(datum.timestamp)}
+          </div>
+        ) : null}
+        <div className={valueClasses} data-testid="tooltip-value">
+          Value: {formatNumber(datum.value)}
+        </div>
+        {referenceProvided ? (
+          <div
+            className={metaClasses}
+            data-testid="tooltip-reference"
+          >
+            Reference: {formatNumber(datum.reference ?? 0)}
+          </div>
+        ) : null}
+        {shouldRenderDelta ? (
+          <div className={metaClasses} data-testid="tooltip-change">
+            Change: {formatSigned(delta.delta ?? 0)}
+            {delta.pct !== null
+              ? ` (${formatSignedPercent(delta.pct)}%)`
+              : ""}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/expert-dashboard/tooltip.ts
+++ b/app/expert-dashboard/tooltip.ts
@@ -1,0 +1,198 @@
+"use client";
+
+export type TooltipDatum = {
+  value: number;
+  reference?: number | null;
+  label?: string;
+  timestamp?: string | number;
+};
+
+export const expertDashboardFlags = {
+  showReferenceDelta: true,
+};
+
+const numberFormatter = new Intl.NumberFormat("id-ID", {
+  maximumFractionDigits: 0,
+});
+
+const percentFormatter = new Intl.NumberFormat("id-ID", {
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 0,
+});
+
+const coerceNumber = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return 0;
+};
+
+const coerceOptionalNumber = (
+  value: unknown
+): number | null | undefined => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+};
+
+export const formatNumber = (value: number): string => {
+  if (!Number.isFinite(value)) return "0";
+  return numberFormatter.format(value);
+};
+
+const formatSignedNumber = (value: number): string => {
+  const absolute = Math.abs(value);
+  const formatted = formatNumber(absolute);
+  if (value > 0) return `+${formatted}`;
+  if (value < 0) return `-${formatted}`;
+  return formatted;
+};
+
+export const formatPercent = (value: number): string => {
+  if (!Number.isFinite(value)) return "0";
+  return percentFormatter.format(value);
+};
+
+const formatSignedPercent = (value: number): string => {
+  const absolute = Math.abs(value);
+  const formatted = formatPercent(absolute);
+  if (value > 0) return `+${formatted}`;
+  if (value < 0) return `-${formatted}`;
+  return formatted;
+};
+
+export const computeDelta = (
+  value: number,
+  reference?: number | null
+): { delta: number | null; pct: number | null } => {
+  if (reference === null || reference === undefined) {
+    return { delta: null, pct: null };
+  }
+
+  const delta = value - reference;
+  if (reference === 0) {
+    return { delta, pct: null };
+  }
+
+  const pct = (delta / reference) * 100;
+  return { delta, pct };
+};
+
+const LABEL_KEYS = [
+  "label",
+  "name",
+  "portal",
+  "segment",
+  "category",
+  "source",
+] as const;
+
+const VALUE_KEYS = ["value", "count", "total", "amount"] as const;
+
+const REFERENCE_KEYS = [
+  "reference",
+  "baseline",
+  "previous",
+  "prev",
+  "prior",
+] as const;
+
+const TIMESTAMP_KEYS = [
+  "timestamp",
+  "date",
+  "period",
+  "week",
+  "time",
+] as const;
+
+const pickFirstKey = <T extends readonly string[]>(
+  raw: Record<string, unknown>,
+  keys: T
+): unknown => {
+  for (const key of keys) {
+    if (key in raw) return raw[key];
+  }
+  return undefined;
+};
+
+export const mapToTooltipDatum = (
+  raw: Record<string, unknown>
+): TooltipDatum => {
+  const value = coerceNumber(pickFirstKey(raw, VALUE_KEYS));
+  const reference = coerceOptionalNumber(
+    pickFirstKey(raw, REFERENCE_KEYS)
+  );
+  const labelValue = pickFirstKey(raw, LABEL_KEYS);
+  const timestampValue = pickFirstKey(raw, TIMESTAMP_KEYS);
+
+  return {
+    value,
+    reference,
+    label:
+      typeof labelValue === "string"
+        ? labelValue
+        : labelValue !== undefined
+        ? String(labelValue)
+        : undefined,
+    timestamp:
+      timestampValue !== undefined
+        ? (timestampValue as string | number)
+        : undefined,
+  };
+};
+
+const formatTimestamp = (timestamp: string | number): string => {
+  if (timestamp instanceof Date) {
+    return timestamp.toISOString();
+  }
+  return String(timestamp);
+};
+
+export const formatTooltipLines = (
+  datum: TooltipDatum
+): string[] => {
+  const lines: string[] = [];
+
+  const label = datum.label?.trim();
+  if (label) {
+    lines.push(label);
+  }
+
+  if (datum.timestamp !== undefined && datum.timestamp !== null) {
+    lines.push(formatTimestamp(datum.timestamp));
+  }
+
+  lines.push(`Value: ${formatNumber(datum.value)}`);
+
+  if (datum.reference !== null && datum.reference !== undefined) {
+    lines.push(`Reference: ${formatNumber(datum.reference)}`);
+
+    if (expertDashboardFlags.showReferenceDelta) {
+      const { delta, pct } = computeDelta(
+        datum.value,
+        datum.reference
+      );
+      if (delta !== null) {
+        let changeLine = `Change: ${formatSignedNumber(delta)}`;
+        if (pct !== null) {
+          changeLine += ` (${formatSignedPercent(pct)}%)`;
+        }
+        lines.push(changeLine);
+      }
+    }
+  }
+
+  return lines;
+};


### PR DESCRIPTION
### Overview

This pull request completes **SCRUM-107**, extending the Expert Dashboard visualization layer to display enhanced data insight in chart tooltips. When reference values are present (such as previous period data or baseline comparison), the tooltip now includes both the reference value and the computed change.

### Key Changes

* Added reusable tooltip content component under `app/expert-dashboard/components/`
* Tooltips now display:

  * Current value
  * Reference value (when available)
  * Change (absolute and percentage), with correct handling for zero or missing reference values
* Implemented safe delta and percentage calculations to avoid divide-by-zero cases
* Centralized data formatting and presentation logic for consistency across chart modes
* Updated tests to cover edge cases and new tooltip rendering behaviors

### Behavior

* If a reference value exists and is non-zero, the tooltip displays value, reference, and `(value - reference)` along with percentage change.
* If reference is zero or null, the tooltip shows only the absolute change.
* If no reference is provided, the tooltip remains unchanged and shows only the primary value.
