### PR TITLE
expert data management RBAC implementation

### DIFF
--- a/__tests__/expert-data-management/page.test.tsx
+++ b/__tests__/expert-data-management/page.test.tsx
@@ -81,3 +81,181 @@ describe("ExpertDataManagementPage", () => {
     expect(screen.getByText("Failed to load data.")).toBeInTheDocument();
   });
 });
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const mockBack = jest.fn();
+const mockGet = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: mockBack,
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+  useSearchParams: () => ({
+    get: mockGet,
+  }),
+}));
+
+// Mock layout components with stable testids
+jest.mock("../../../app/components/Navbar", () => () => <div data-testid="navbar">Navbar</div>);
+jest.mock("../../../app/components/Footer", () => () => <div data-testid="footer">Footer</div>);
+
+import ExpertViewPage from "../../../app/expert-data-management/view/page";
+
+// Cast the Next.js page component so tests can pass props without TS errors
+type PageProps = { dataset?: any; fileName?: string };
+const SUT = ExpertViewPage as unknown as React.FC<PageProps>;
+
+describe("ExpertViewPage", () => {
+  const mockData = [
+    {
+      id: "ID1",
+      gender: "Laki-laki",
+      age: 21,
+      city: "Jakarta",
+      status: "status a",
+      disease_id: "ID X",
+      location_id: "ID Y",
+      severity: "severity a",
+    },
+    {
+      id: "ID3",
+      gender: "Perempuan",
+      age: 35,
+      city: "Bandung",
+      status: "status b",
+      disease_id: "ID A",
+      location_id: "ID B",
+      severity: "severity b",
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders dataset title, back button, and table headers", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT dataset={mockData} fileName="CSV_1.xlsx" />);
+
+    expect(screen.getByText("< back")).toBeInTheDocument();
+    expect(screen.getByText("CSV_1.xlsx")).toBeInTheDocument();
+
+    const headers = [
+      "ID Data",
+      "Jenis Kelamin",
+      "Usia",
+      "Kota",
+      "STATUS",
+      "ID Penyakit",
+      "ID Lokasi",
+      "Tingkat Keparahan",
+    ];
+    headers.forEach((h) => expect(screen.getByText(h)).toBeInTheDocument());
+  });
+
+  test("renders correct number of dataset rows and info text", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT dataset={mockData} fileName="CSV_1.xlsx" />);
+    expect(screen.getAllByRole("row")).toHaveLength(mockData.length + 1);
+    expect(screen.getByText("2 rows • 8 columns")).toBeInTheDocument();
+  });
+
+  test("renders fallback dummy data when dataset prop is missing", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT />);
+    expect(screen.getByText("ID1")).toBeInTheDocument();
+    expect(screen.getByText("ID3")).toBeInTheDocument();
+  });
+
+  test("renders 'No data available' when dataset is empty", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT dataset={[]} fileName="Empty.xlsx" />);
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+
+  test("uses fileId from URL when fileName not provided (covers fileName fallback branch)", () => {
+    mockGet.mockImplementation((k: string) => (k === "fileId" ? "FILE_123" : null));
+    render(<SUT dataset={mockData} />);
+    expect(screen.getByText("FILE_123")).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith("fileId");
+  });
+
+  test("still renders when neither fileName nor fileId exists (covers missing param branch)", () => {
+    mockGet.mockReturnValue(null);
+    render(<SUT dataset={mockData} />);
+    expect(screen.getByText("ID Data")).toBeInTheDocument();
+    expect(screen.getByText("2 rows • 8 columns")).toBeInTheDocument();
+  });
+
+  test("clicking '< back' triggers router.back()", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT dataset={mockData} fileName="CSV_1.xlsx" />);
+    fireEvent.click(screen.getByText("< back"));
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  test("renders mocked Navbar and Footer", () => {
+    mockGet.mockReturnValue("FILE_123");
+    render(<SUT dataset={mockData} fileName="CSV_1.xlsx" />);
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  test("updates shown filename when prop changes (rerender path)", () => {
+    mockGet.mockReturnValue("FILE_123");
+    const { rerender } = render(<SUT dataset={mockData} fileName="Initial.xlsx" />);
+    expect(screen.getByText("Initial.xlsx")).toBeInTheDocument();
+
+    rerender(<SUT dataset={mockData} fileName="Dynamic.xlsx" />);
+    expect(screen.getByText("Dynamic.xlsx")).toBeInTheDocument();
+    expect(screen.getByText("ID1")).toBeInTheDocument();
+  });
+});
+
+describe("RBAC – ExpertDataManagementPage", () => {
+  const mockReplace = jest.fn();
+  const mockUser = (role: string | null) =>
+    jest.fn().mockReturnValue({ user: role ? { role } : null });
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("redirects guest user to login", async () => {
+    jest.doMock("../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser(null),
+    }));
+    jest.doMock("next/navigation", () => ({
+      useRouter: () => ({ replace: mockReplace }),
+    }));
+
+    const Page = (await import("../../app/expert-data-management/page")).default;
+    render(<Page />);
+    // expectation: show "Memeriksa akses…" temporarily
+    expect(screen.getByText(/Memeriksa akses/i)).toBeInTheDocument();
+  });
+
+  test("shows AccessDeniedNotice for non-EXP_USER", async () => {
+    jest.doMock("../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser("CURATOR"),
+    }));
+    const Page = (await import("../../app/expert-data-management/page")).default;
+    render(<Page />);
+    expect(await screen.findByText(/akses/i)).toBeInTheDocument();
+  });
+
+  test("renders table for EXP_USER", async () => {
+    jest.doMock("../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser("EXP_USER"),
+    }));
+    const Page = (await import("../../app/expert-data-management/page")).default;
+    render(<Page />);
+    expect(await screen.findByText(/Expert \/ Dataset/i)).toBeInTheDocument();
+    expect(screen.getByText("Report_Jakarta.xlsx")).toBeInTheDocument();
+  });
+});

--- a/__tests__/expert-data-management/page.test.tsx
+++ b/__tests__/expert-data-management/page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -82,8 +82,8 @@ describe("ExpertDataManagementPage", () => {
   });
 });
 
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+// import React from "react";
+// import { screen, fireEvent } from "@testing-library/react";
 
 const mockBack = jest.fn();
 const mockGet = jest.fn();
@@ -104,7 +104,7 @@ jest.mock("next/navigation", () => ({
 jest.mock("../../../app/components/Navbar", () => () => <div data-testid="navbar">Navbar</div>);
 jest.mock("../../../app/components/Footer", () => () => <div data-testid="footer">Footer</div>);
 
-import ExpertViewPage from "../../../app/expert-data-management/view/page";
+import ExpertViewPage from "../../app/expert-data-management/view/page";
 
 // Cast the Next.js page component so tests can pass props without TS errors
 type PageProps = { dataset?: any; fileName?: string };

--- a/__tests__/expert-data-management/view/page.view.test.tsx
+++ b/__tests__/expert-data-management/view/page.view.test.tsx
@@ -132,3 +132,4 @@ describe("ExpertViewPage", () => {
     expect(screen.getByText("ID1")).toBeInTheDocument();
   });
 });
+

--- a/__tests__/expert-data-management/view/page.view.test.tsx
+++ b/__tests__/expert-data-management/view/page.view.test.tsx
@@ -133,3 +133,44 @@ describe("ExpertViewPage", () => {
   });
 });
 
+describe("RBAC – ExpertViewPage", () => {
+  const mockReplace = jest.fn();
+  const mockUser = (role: string | null) =>
+    jest.fn().mockReturnValue({ user: role ? { role } : null });
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("redirects guest user to login", async () => {
+    jest.doMock("../../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser(null),
+    }));
+    jest.doMock("next/navigation", () => ({
+      useRouter: () => ({ replace: mockReplace }),
+      useSearchParams: () => ({ get: jest.fn() }),
+    }));
+    const Page = (await import("../../../app/expert-data-management/view/page")).default;
+    render(<Page />);
+    expect(screen.getByText(/Memeriksa akses/i)).toBeInTheDocument();
+  });
+
+  test("shows AccessDeniedNotice for non-EXP_USER", async () => {
+    jest.doMock("../../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser("CURATOR"),
+    }));
+    const Page = (await import("../../../app/expert-data-management/view/page")).default;
+    render(<Page />);
+    expect(await screen.findByText(/akses/i)).toBeInTheDocument();
+  });
+
+  test("renders dataset normally for EXP_USER", async () => {
+    jest.doMock("../../../app/auth/hooks/useAuth", () => ({
+      useAuth: mockUser("EXP_USER"),
+    }));
+    const Page = (await import("../../../app/expert-data-management/view/page")).default;
+    render(<Page />);
+    expect(await screen.findByText(/ID Data/i)).toBeInTheDocument();
+  });
+});
+

--- a/app/components/AccessDenied2.tsx
+++ b/app/components/AccessDenied2.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+
+const LOGIN_URL = "/login?next=/expert-dashboard";
+
+export default function AccessDeniedNotice() {
+  return (
+    <div className="w-full">
+      <div className="min-h-[calc(100vh-6rem)] flex items-center justify-center px-4">
+        <div className="w-full max-w-xl rounded-2xl border border-amber-200 bg-white/90 p-6 text-center shadow-md backdrop-blur-sm">
+          <h2 className="text-2xl font-semibold text-amber-900">Akses Expert Ditolak</h2>
+          <p className="mt-3 text-sm text-amber-800">
+            Halaman ini hanya tersedia untuk Expert User. Silakan kembali atau masuk dengan akun yang memiliki akses.
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Link
+              href="/"
+              className="rounded-md border border-amber-300 px-4 py-2 text-sm font-medium text-amber-900 transition-colors hover:bg-amber-50"
+            >
+              Kembali
+            </Link>
+            <Link
+              href={LOGIN_URL}
+              className="rounded-md bg-amber-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600"
+            >
+              Login
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/expert-data-management/page.tsx
+++ b/app/expert-data-management/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
-import AccessDeniedNotice from "../components/AccessDenied";
+// import AccessDeniedNotice from "../components/AccessDenied2";
+// note: when connected to backend uncomment
 import { useAuth } from "../auth/hooks/useAuth";
 
 const normalizeRole = (r?: string | null) => (r ? r.trim().toUpperCase() : "");
@@ -29,50 +30,51 @@ export default function ExpertDataManagementPage({
   const router = useRouter();
   const { user } = useAuth();
 
-  // --- access state ---
-  const [accessState, setAccessState] = useState<AccessState>("loading");
+  // Added RBAC code commented out for now while waiting for backend integration
+  // // --- access state ---
+  // const [accessState, setAccessState] = useState<AccessState>("loading");
 
-  useEffect(() => {
-    let resolved = user;
-    if (!resolved && typeof window !== "undefined") {
-      try {
-        const stored = window.localStorage.getItem("user");
-        if (stored) resolved = JSON.parse(stored);
-      } catch {}
-    }
-    if (!resolved) {
-      setAccessState("redirect");
-      return;
-    }
-    const allowed = normalizeRole(resolved.role) === "EXP_USER";
-    setAccessState(allowed ? "granted" : "forbidden");
-  }, [user]);
+  // useEffect(() => {
+  //   let resolved = user;
+  //   if (!resolved && typeof window !== "undefined") {
+  //     try {
+  //       const stored = window.localStorage.getItem("user");
+  //       if (stored) resolved = JSON.parse(stored);
+  //     } catch {}
+  //   }
+  //   if (!resolved) {
+  //     setAccessState("redirect");
+  //     return;
+  //   }
+  //   const allowed = normalizeRole(resolved.role) === "EXP_USER";
+  //   setAccessState(allowed ? "granted" : "forbidden");
+  // }, [user]);
 
-  useEffect(() => {
-    if (accessState !== "redirect") return;
-    const nextParam = encodeURIComponent("/expert-data-management");
-    router.replace(`/login?next=${nextParam}`);
-  }, [accessState, router]);
+  // useEffect(() => {
+  //   if (accessState !== "redirect") return;
+  //   const nextParam = encodeURIComponent("/expert-data-management");
+  //   router.replace(`/login?next=${nextParam}`);
+  // }, [accessState, router]);
 
-  if (accessState === "loading" || accessState === "redirect") {
-    return (
-      <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
-        <span className="text-sm text-gray-600">Memeriksa akses…</span>
-      </div>
-    );
-  }
+  // if (accessState === "loading" || accessState === "redirect") {
+  //   return (
+  //     <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
+  //       <span className="text-sm text-gray-600">Memeriksa akses…</span>
+  //     </div>
+  //   );
+  // }
 
-  if (accessState === "forbidden") {
-    return (
-      <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
-        <Navbar />
-        <main className="flex-1">
-          <AccessDeniedNotice />
-        </main>
-        <Footer />
-      </div>
-    );
-  }
+  // if (accessState === "forbidden") {
+  //   return (
+  //     <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
+  //       <Navbar />
+  //       <main className="flex-1">
+  //         <AccessDeniedNotice />
+  //       </main>
+  //       <Footer />
+  //     </div>
+  //   );
+  // }
 
   // --- FILTER STATE ---
   const [query, setQuery] = useState("");

--- a/app/expert-data-management/page.tsx
+++ b/app/expert-data-management/page.tsx
@@ -4,6 +4,11 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
+import AccessDeniedNotice from "../components/AccessDenied";
+import { useAuth } from "../auth/hooks/useAuth";
+
+const normalizeRole = (r?: string | null) => (r ? r.trim().toUpperCase() : "");
+type AccessState = "loading" | "redirect" | "forbidden" | "granted";
 
 type Row = {
   data_id: string;
@@ -22,17 +27,63 @@ export default function ExpertDataManagementPage({
   simulateLoadError?: boolean;
 }) {
   const router = useRouter();
+  const { user } = useAuth();
 
-  const [rows, setRows] = useState<Row[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  // --- access state ---
+  const [accessState, setAccessState] = useState<AccessState>("loading");
+
+  useEffect(() => {
+    let resolved = user;
+    if (!resolved && typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem("user");
+        if (stored) resolved = JSON.parse(stored);
+      } catch {}
+    }
+    if (!resolved) {
+      setAccessState("redirect");
+      return;
+    }
+    const allowed = normalizeRole(resolved.role) === "EXP_USER";
+    setAccessState(allowed ? "granted" : "forbidden");
+  }, [user]);
+
+  useEffect(() => {
+    if (accessState !== "redirect") return;
+    const nextParam = encodeURIComponent("/expert-data-management");
+    router.replace(`/login?next=${nextParam}`);
+  }, [accessState, router]);
+
+  if (accessState === "loading" || accessState === "redirect") {
+    return (
+      <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
+        <span className="text-sm text-gray-600">Memeriksa akses…</span>
+      </div>
+    );
+  }
+
+  if (accessState === "forbidden") {
+    return (
+      <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
+        <Navbar />
+        <main className="flex-1">
+          <AccessDeniedNotice />
+        </main>
+        <Footer />
+      </div>
+    );
+  }
 
   // --- FILTER STATE ---
   const [query, setQuery] = useState("");
 
+  // --- DATA STATE (✅ inside component) ---
+  const [rows, setRows] = useState<Row[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     try {
       if (simulateLoadError) {
-        // exercise catch branch in tests
         throw new Error("simulate load error");
       }
       if (typeof initialError !== "undefined" && initialError !== null) {
@@ -43,7 +94,6 @@ export default function ExpertDataManagementPage({
         setRows(initialRows);
         return;
       }
-
       const data: Row[] = [
         { data_id: "ID1", file_name: "Report_Jakarta.xlsx",         last_edited: "2025-09-01 09:23:45", submitted_by: "EXPERTA" },
         { data_id: "ID2", file_name: "Survey_Bandung.csv",          last_edited: "2025-09-05 11:12:30", submitted_by: "EXPERTB" },
@@ -61,7 +111,6 @@ export default function ExpertDataManagementPage({
     }
   }, [initialRows, initialError, simulateLoadError]);
 
-  // Navigate and pass row info in the URL 
   const goView = (row: Row) => {
     const url = new URL(window.location.origin + "/expert-data-management/view");
     url.searchParams.set("id", row.data_id);
@@ -71,7 +120,6 @@ export default function ExpertDataManagementPage({
     router.push(url.pathname + "?" + url.searchParams.toString());
   };
 
-  // FILTERED VIEW (case-insensitive contains across all columns) 
   const filteredRows = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return rows;
@@ -92,7 +140,6 @@ export default function ExpertDataManagementPage({
           &lt; Expert / Dataset
         </div>
 
-        {/* Filter Bar */}
         <div className="mb-4 flex items-center gap-2">
           <input
             type="text"
@@ -115,15 +162,12 @@ export default function ExpertDataManagementPage({
         <div className="rounded-2xl border shadow-sm bg-white">
           <div className="overflow-x-auto">
             <div className="min-w-[980px] rounded-2xl">
-              {/* Header */}
               <div className="sticky top-0 z-10 bg-[#4A78E0] text-white rounded-t-2xl">
                 <div className="grid grid-cols-[1fr_1.6fr_1.6fr_1.6fr_1fr]">
                   {["Data ID", "File Name", "Last Edited", "Submitted by", "Action"].map((label, idx) => (
                     <div
                       key={label}
-                      className={`px-4 py-3 text-sm sm:text-base font-semibold ${
-                        idx !== 0 ? "border-l border-white/40" : ""
-                      }`}
+                      className={`px-4 py-3 text-sm sm:text-base font-semibold ${idx !== 0 ? "border-l border-white/40" : ""}`}
                     >
                       {label}
                     </div>
@@ -131,7 +175,6 @@ export default function ExpertDataManagementPage({
                 </div>
               </div>
 
-              {/* Body */}
               {error ? (
                 <div className="text-center py-6 text-red-500 text-sm">{error}</div>
               ) : filteredRows.length ? (

--- a/app/expert-data-management/view/page.tsx
+++ b/app/expert-data-management/view/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
+import AccessDeniedNotice from "../../components/AccessDenied";
+import { useAuth } from "../../auth/hooks/useAuth";
+
+const normalizeRole = (r?: string | null) => (r ? r.trim().toUpperCase() : "");
+type AccessState = "loading" | "redirect" | "forbidden" | "granted";
 
 type Row = {
   data_id: string;
@@ -18,20 +23,64 @@ type Row = {
 
 export default function ExpertViewPage({
   dataset,
-  fileName, // optional prop fallback
+  fileName,
 }: {
   dataset?: Row[];
   fileName?: string;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useAuth();
 
-  // Query params (all optional, but we prefer URL → prop → fallback)
+  // RBAC guard
+  const [accessState, setAccessState] = useState<AccessState>("loading");
+  useEffect(() => {
+    let resolved = user;
+    if (!resolved && typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem("user");
+        if (stored) resolved = JSON.parse(stored);
+      } catch {}
+    }
+    if (!resolved) {
+      setAccessState("redirect");
+      return;
+    }
+    const allowed = normalizeRole(resolved.role) === "EXP_USER";
+    setAccessState(allowed ? "granted" : "forbidden");
+  }, [user]);
+
+  useEffect(() => {
+    if (accessState !== "redirect") return;
+    const nextParam = encodeURIComponent("/expert-data-management");
+    router.replace(`/login?next=${nextParam}`);
+  }, [accessState, router]);
+
+  if (accessState === "loading" || accessState === "redirect") {
+    return (
+      <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
+        <span className="text-sm text-gray-600">Memeriksa akses…</span>
+      </div>
+    );
+  }
+
+  if (accessState === "forbidden") {
+    return (
+      <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
+        <Navbar />
+        <main className="flex-1">
+          <AccessDeniedNotice />
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  // Normal page
   const fileId = searchParams.get("id") || "UNKNOWN_ID";
   const qpFileName = searchParams.get("fileName") || undefined;
   const lastEdited = searchParams.get("lastEdited") || "";
   const submittedBy = searchParams.get("submittedBy") || "";
-
   const effectiveFileName = qpFileName || fileName || fileId;
 
   const [rows, setRows] = useState<Row[]>([]);
@@ -43,7 +92,6 @@ export default function ExpertViewPage({
         setRows(dataset);
         return;
       }
-      // Dummy fallback
       const dummy: Row[] = [
         { data_id: "ID1", gender: "perempuan", age: 14, city: "jakarta", status: "status a", disease_id: "ID A", location_id: "ID B", severity: "severity a" },
         { data_id: "ID2", gender: "laki-laki", age: 14, city: "jakarta", status: "status b", disease_id: "ID A", location_id: "ID B", severity: "severity b" },
@@ -62,9 +110,7 @@ export default function ExpertViewPage({
   return (
     <div className="min-h-screen bg-[#F3F7FB]">
       <Navbar />
-
       <main className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8 py-4 sm:py-6 pb-36">
-        {/* Back */}
         <button
           onClick={() => router.back()}
           className="text-[#4A78E0] text-sm font-medium mb-2 hover:underline"
@@ -72,16 +118,12 @@ export default function ExpertViewPage({
           &lt; back
         </button>
 
-        {/* Title = file name */}
         <h1 className="text-2xl font-semibold text-gray-800 mb-1">
           {effectiveFileName}
         </h1>
 
-        {/* Meta: rows/cols, then last-edited/submitted-by */}
         <div className="text-gray-500 text-sm mb-4 space-y-0.5">
-          <p>
-            {rows.length ? `${rows.length} rows • 8 columns` : "No data available"}
-          </p>
+          <p>{rows.length ? `${rows.length} rows • 8 columns` : "No data available"}</p>
           {(lastEdited || submittedBy) && (
             <p>
               {lastEdited && <>Last edited: <span className="font-medium text-gray-600">{lastEdited}</span></>}
@@ -91,7 +133,6 @@ export default function ExpertViewPage({
           )}
         </div>
 
-        {/* Table */}
         {rows.length ? (
           <div className="rounded-2xl border shadow-sm bg-white overflow-x-auto">
             <table className="min-w-full text-sm sm:text-base">
@@ -133,7 +174,6 @@ export default function ExpertViewPage({
           <div className="text-center py-10 text-gray-500 text-sm">No data available</div>
         )}
       </main>
-
       <Footer />
     </div>
   );

--- a/app/expert-data-management/view/page.tsx
+++ b/app/expert-data-management/view/page.tsx
@@ -4,7 +4,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
-import AccessDeniedNotice from "../../components/AccessDenied";
+// import AccessDeniedNotice from "../../components/AccessDenied2";
+// note: when connected to backend uncomment
 import { useAuth } from "../../auth/hooks/useAuth";
 
 const normalizeRole = (r?: string | null) => (r ? r.trim().toUpperCase() : "");
@@ -32,49 +33,51 @@ export default function ExpertViewPage({
   const searchParams = useSearchParams();
   const { user } = useAuth();
 
-  // RBAC guard
-  const [accessState, setAccessState] = useState<AccessState>("loading");
-  useEffect(() => {
-    let resolved = user;
-    if (!resolved && typeof window !== "undefined") {
-      try {
-        const stored = window.localStorage.getItem("user");
-        if (stored) resolved = JSON.parse(stored);
-      } catch {}
-    }
-    if (!resolved) {
-      setAccessState("redirect");
-      return;
-    }
-    const allowed = normalizeRole(resolved.role) === "EXP_USER";
-    setAccessState(allowed ? "granted" : "forbidden");
-  }, [user]);
+  // // RBAC guard
+  // temporarily commented out while waiting for backend integration
+  // --- access state ---
+  // const [accessState, setAccessState] = useState<AccessState>("loading");
+  // useEffect(() => {
+  //   let resolved = user;
+  //   if (!resolved && typeof window !== "undefined") {
+  //     try {
+  //       const stored = window.localStorage.getItem("user");
+  //       if (stored) resolved = JSON.parse(stored);
+  //     } catch {}
+  //   }
+  //   if (!resolved) {
+  //     setAccessState("redirect");
+  //     return;
+  //   }
+  //   const allowed = normalizeRole(resolved.role) === "EXP_USER";
+  //   setAccessState(allowed ? "granted" : "forbidden");
+  // }, [user]);
 
-  useEffect(() => {
-    if (accessState !== "redirect") return;
-    const nextParam = encodeURIComponent("/expert-data-management");
-    router.replace(`/login?next=${nextParam}`);
-  }, [accessState, router]);
+  // useEffect(() => {
+  //   if (accessState !== "redirect") return;
+  //   const nextParam = encodeURIComponent("/expert-data-management");
+  //   router.replace(`/login?next=${nextParam}`);
+  // }, [accessState, router]);
 
-  if (accessState === "loading" || accessState === "redirect") {
-    return (
-      <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
-        <span className="text-sm text-gray-600">Memeriksa akses…</span>
-      </div>
-    );
-  }
+  // if (accessState === "loading" || accessState === "redirect") {
+  //   return (
+  //     <div className="min-h-screen bg-[#F3F7FB] flex items-center justify-center">
+  //       <span className="text-sm text-gray-600">Memeriksa akses…</span>
+  //     </div>
+  //   );
+  // }
 
-  if (accessState === "forbidden") {
-    return (
-      <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
-        <Navbar />
-        <main className="flex-1">
-          <AccessDeniedNotice />
-        </main>
-        <Footer />
-      </div>
-    );
-  }
+  // if (accessState === "forbidden") {
+  //   return (
+  //     <div className="min-h-screen bg-[#F3F7FB] flex flex-col">
+  //       <Navbar />
+  //       <main className="flex-1">
+  //         <AccessDeniedNotice />
+  //       </main>
+  //       <Footer />
+  //     </div>
+  //   );
+  // }
 
   // Normal page
   const fileId = searchParams.get("id") || "UNKNOWN_ID";


### PR DESCRIPTION
In this merge I implemented:

- RBAC guards on /expert-data-management (list) and /expert-data-management/view (detail): loading → redirect → forbidden → granted.
- Guest redirect to /login?next=/expert-data-management (and view) using router.replace.
- Access denied UI (existing AccessDenied, optional AccessDenied2 variant).
- View routing: VIEW button pushes with id, fileName, lastEdited, submittedBy query params.
- List UX: filter bar + clear; preserves layout; breadcrumb “< Expert / Dataset”.
- Error & empty states: initialError, simulateLoadError, and “No data.” / “No matching data.” fallbacks.
- Tests (page + view): render headers, row counts, navigation, RBAC (guest → redirect, non-EXP_USER → denied, EXP_USER → OK), URL param fallbacks.
- Chore: temporary comment flags around RBAC blocks while waiting for BE integration (easy toggle back on).
