### PR TITLE
Pbi 14 spatial comparison

### DIFF
--- a/__tests__/app/map/page.test.tsx
+++ b/__tests__/app/map/page.test.tsx
@@ -89,7 +89,7 @@ jest.mock("../../../app/components/filter/MultiSelectForm", () => ({
             level_of_alertness: 1,
             portals: ["news-1"],
             start_date: new Date("2023-01-01"),
-            end_date: new Date("2023-12-31")
+            end_date: new Date("2023-12-31"),
             batch: "batch-1"
           })}
           data-testid="submit-filter"
@@ -118,6 +118,11 @@ jest.mock("../../../app/components/floating_buttons/FilterButton", () => ({
       {isActive ? "Hide Filters" : "Show Filters"}
     </button>
   )),
+}));
+
+jest.mock("../../../app/components/spatial/SpatialComparisonPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spatial-comparison-panel">Spatial comparison mock</div>,
 }));
 
 describe("MapPage Component", () => {

--- a/__tests__/components/SpatialComparisonPanel.test.tsx
+++ b/__tests__/components/SpatialComparisonPanel.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SpatialComparisonPanel from "../../app/components/spatial/SpatialComparisonPanel";
+import { useSpatialComparisons } from "../../hooks/useSpatialComparisons";
+import { FilterState } from "../../types";
+import React from "react";
+
+jest.mock("../../hooks/useSpatialComparisons");
+
+let mockLatestMapService: Record<string, jest.Mock> | null = null;
+
+jest.mock("../../app/components/IndonesiaMap", () => {
+  const React = require("react");
+  return {
+    IndonesiaMap: (props: any) => {
+      React.useEffect(() => {
+        if (props.onMapReady) {
+          mockLatestMapService = {
+            hideAllLayers: jest.fn(),
+            showPrecipitationLayer: jest.fn(),
+            showHumidityLayer: jest.fn(),
+            showTemperatureLayer: jest.fn(),
+            showSeverityLayer: jest.fn(),
+          };
+          props.onMapReady(mockLatestMapService);
+        }
+      }, [props.onMapReady]);
+      return <div data-testid={`map-${props.mapId}`}>Map {props.mapId}</div>;
+    },
+  };
+});
+
+const baseFilters: FilterState = {
+  diseases: [],
+  locations: [],
+  level_of_alertness: 0,
+  portals: [],
+  start_date: null,
+  end_date: null,
+  batch: null,
+};
+
+const provinceData = [];
+
+describe("SpatialComparisonPanel", () => {
+  beforeEach(() => {
+    mockLatestMapService = null;
+    (useSpatialComparisons as jest.Mock).mockReturnValue({
+      comparisons: [],
+      isLoading: false,
+      error: null,
+      lastUpdated: null,
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          locations: {
+            provinces: [{ value: "Jakarta", label: "Jakarta" }],
+            cities: [{ value: "Bandung", label: "Bandung" }],
+          },
+        },
+      }),
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows guidance when less than two regions are selected", async () => {
+    render(
+      <SpatialComparisonPanel
+        baseFilters={baseFilters}
+        refreshToken={0}
+        onError={jest.fn()}
+        provinceHumidityData={provinceData}
+        provinceTemperatureData={provinceData}
+        provincePrecipitationData={provinceData}
+        provinceSeverityData={provinceData}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByTestId("comparison-status")).toBeInTheDocument());
+    expect(screen.getByTestId("comparison-status")).toHaveTextContent("minimal dua wilayah");
+  });
+
+  it("renders comparison cards and applies metric toggles to the map service", async () => {
+    (useSpatialComparisons as jest.Mock).mockReturnValue({
+      comparisons: [
+        {
+          label: "Jakarta",
+          count: 2,
+          locations: [
+            { id: "1", city: "Jakarta", location__latitude: -6.2, location__longitude: 106.8, location__province: "DKI" },
+          ],
+          filters: {},
+        },
+      ],
+      isLoading: false,
+      error: null,
+      lastUpdated: new Date("2025-01-01T00:00:00Z"),
+    });
+
+    render(
+      <SpatialComparisonPanel
+        baseFilters={baseFilters}
+        refreshToken={0}
+        onError={jest.fn()}
+        provinceHumidityData={provinceData}
+        provinceTemperatureData={provinceData}
+        provincePrecipitationData={provinceData}
+        provinceSeverityData={provinceData}
+        initialRegions={[
+          { value: "Jakarta", label: "Jakarta" },
+          { value: "Bandung", label: "Bandung" },
+        ]}
+      />
+    );
+
+    await waitFor(() => expect(screen.getAllByTestId("comparison-card").length).toBe(1));
+    expect(mockLatestMapService?.hideAllLayers).toHaveBeenCalled();
+
+    const metricSelect = screen.getByTestId("metric-select");
+    fireEvent.change(metricSelect, { target: { value: "humidity" } });
+    expect(mockLatestMapService?.showHumidityLayer).toHaveBeenCalled();
+
+    fireEvent.change(metricSelect, { target: { value: "precipitation" } });
+    expect(mockLatestMapService?.showPrecipitationLayer).toHaveBeenCalled();
+  });
+
+  it("applies selected regions when clicking sinkronkan filter", async () => {
+    render(
+      <SpatialComparisonPanel
+        baseFilters={baseFilters}
+        refreshToken={0}
+        onError={jest.fn()}
+        provinceHumidityData={provinceData}
+        provinceTemperatureData={provinceData}
+        provincePrecipitationData={provinceData}
+        provinceSeverityData={provinceData}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByTestId("region-a-select")).toBeInTheDocument());
+
+    // Select first option
+    const regionSelectA = screen.getByTestId("region-a-select").querySelector("input");
+    const regionSelectB = screen.getByTestId("region-b-select").querySelector("input");
+    if (regionSelectA && regionSelectB) {
+      fireEvent.focus(regionSelectA);
+      fireEvent.change(regionSelectA, { target: { value: "Jakarta" } });
+      fireEvent.keyDown(regionSelectA, { key: "Enter", code: "Enter" });
+
+      fireEvent.focus(regionSelectB);
+      fireEvent.change(regionSelectB, { target: { value: "Bandung" } });
+      fireEvent.keyDown(regionSelectB, { key: "Enter", code: "Enter" });
+    }
+
+    fireEvent.click(screen.getByTestId("refresh-comparison"));
+
+    expect(screen.getByTestId("comparison-status")).toBeInTheDocument();
+  });
+
+  it("displays API errors from the comparison hook", async () => {
+    (useSpatialComparisons as jest.Mock).mockReturnValue({
+      comparisons: [],
+      isLoading: false,
+      error: new Error("Comparison failed"),
+      lastUpdated: null,
+    });
+
+    render(
+      <SpatialComparisonPanel
+        baseFilters={baseFilters}
+        refreshToken={0}
+        onError={jest.fn()}
+        provinceHumidityData={provinceData}
+        provinceTemperatureData={provinceData}
+        provincePrecipitationData={provinceData}
+        provinceSeverityData={provinceData}
+        initialRegions={[
+          { value: "Jakarta", label: "Jakarta" },
+          { value: "Bandung", label: "Bandung" },
+        ]}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByTestId("comparison-status")).toBeInTheDocument());
+    expect(screen.getByTestId("comparison-status")).toHaveTextContent("Comparison failed");
+  });
+});

--- a/__tests__/dashboard/Page.test.tsx
+++ b/__tests__/dashboard/Page.test.tsx
@@ -92,7 +92,7 @@ describe("Dashboard Page", () => {
       level_of_alertness: 3,
       portals: ["news-portal-1", "news-portal-2"],
       start_date: new Date(),
-      end_date: new Date() 
+      end_date: new Date(), 
       batch: "batch-1"
     };
     

--- a/__tests__/filter/MultiSelectForm.test.tsx
+++ b/__tests__/filter/MultiSelectForm.test.tsx
@@ -532,7 +532,7 @@ describe("MultiSelectForm Component", () => {
           portals: [],
           level_of_alertness: 0,
           start_date: null,
-          end_date: null
+          end_date: null,
           batch: null
         })
       );

--- a/__tests__/hooks/useLocations.test.ts
+++ b/__tests__/hooks/useLocations.test.ts
@@ -171,4 +171,27 @@ describe('useLocations', () => {
     expect(mapApi.getFilteredLocations).toHaveBeenCalledTimes(2);
     expect(mapApi.getFilteredLocations).toHaveBeenLastCalledWith(updatedFilterState);
   });
+
+  it("should refetch when refreshToken changes even if filters stay the same", async () => {
+    const first = [{ id: "1", city: "A", location__latitude: 1, location__longitude: 1, location__province: "P1" }];
+    const second = [{ id: "2", city: "B", location__latitude: 2, location__longitude: 2, location__province: "P2" }];
+    (mapApi.getFilteredLocations as jest.Mock)
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    const { result, rerender } = renderHook(
+      (props: { refresh: number }) => useLocations(defaultFilterState, props.refresh),
+      { initialProps: { refresh: 0 } }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(first);
+    expect(mapApi.getFilteredLocations).toHaveBeenCalledTimes(1);
+
+    rerender({ refresh: 1 });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(second);
+    expect(mapApi.getFilteredLocations).toHaveBeenCalledTimes(2);
+  });
 });

--- a/__tests__/hooks/useSpatialComparisons.test.ts
+++ b/__tests__/hooks/useSpatialComparisons.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSpatialComparisons } from "../../hooks/useSpatialComparisons";
+import { mapApi } from "../../services/api";
+import { FilterState, SpatialComparisonRegion } from "../../types";
+
+jest.mock("../../services/api", () => ({
+  mapApi: {
+    getSpatialComparisons: jest.fn(),
+  },
+}));
+
+const baseFilters: FilterState = {
+  diseases: [],
+  locations: [],
+  level_of_alertness: 0,
+  portals: [],
+  start_date: null,
+  end_date: null,
+  batch: null,
+};
+
+const sampleRegions: SpatialComparisonRegion[] = [
+  { value: "Jakarta", label: "Jakarta" },
+  { value: "Bandung", label: "Bandung" },
+];
+
+describe("useSpatialComparisons", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches comparisons when enabled and regions are provided", async () => {
+    const mockResponse = {
+      comparisons: [
+        {
+          label: "Jakarta",
+          count: 2,
+          locations: [
+            { id: "1", city: "Jakarta", location__latitude: -6.2, location__longitude: 106.8, location__province: "DKI" },
+          ],
+          filters: {},
+        },
+      ],
+    };
+
+    (mapApi.getSpatialComparisons as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() =>
+      useSpatialComparisons({
+        regions: sampleRegions,
+        baseFilters,
+        enabled: true,
+        refreshToken: 0,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.comparisons).toEqual(mockResponse.comparisons);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).not.toBeNull();
+    expect(mapApi.getSpatialComparisons).toHaveBeenCalledTimes(1);
+    expect(mapApi.getSpatialComparisons).toHaveBeenCalledWith({
+      regions: expect.any(Array),
+    });
+  });
+
+  it("skips fetching when disabled or fewer than two regions", async () => {
+    const { result } = renderHook(() =>
+      useSpatialComparisons({
+        regions: [],
+        baseFilters,
+        enabled: false,
+        refreshToken: 0,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.comparisons).toEqual([]);
+    expect(mapApi.getSpatialComparisons).not.toHaveBeenCalled();
+  });
+
+  it("handles errors from API", async () => {
+    (mapApi.getSpatialComparisons as jest.Mock).mockRejectedValueOnce(new Error("API failed"));
+
+    const { result } = renderHook(() =>
+      useSpatialComparisons({
+        regions: sampleRegions,
+        baseFilters,
+        enabled: true,
+        refreshToken: 0,
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toEqual(new Error("API failed"));
+    expect(result.current.comparisons).toEqual([]);
+  });
+
+  it("refetches when refreshToken changes even if filters stay the same", async () => {
+    const firstResponse = { comparisons: [], lastUpdated: null };
+    const secondResponse = { comparisons: [{ label: "Bandung", count: 1, locations: [], filters: {} }] };
+    (mapApi.getSpatialComparisons as jest.Mock)
+      .mockResolvedValueOnce(firstResponse)
+      .mockResolvedValueOnce(secondResponse);
+
+    const { result, rerender } = renderHook(
+      (props: { refreshToken: number }) =>
+        useSpatialComparisons({
+          regions: sampleRegions,
+          baseFilters,
+          enabled: true,
+          refreshToken: props.refreshToken,
+        }),
+      { initialProps: { refreshToken: 0 } }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mapApi.getSpatialComparisons).toHaveBeenCalledTimes(1);
+
+    rerender({ refreshToken: 1 });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mapApi.getSpatialComparisons).toHaveBeenCalledTimes(2);
+    expect(result.current.comparisons).toEqual(secondResponse.comparisons);
+  });
+});

--- a/__tests__/map/MapPage.test.tsx
+++ b/__tests__/map/MapPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import MapPage from "../../app/map/page";
 import { useLocations } from "../../hooks/useLocations";
@@ -48,6 +48,11 @@ jest.mock("../../app/components/MapLoadErrorPopup", () => ({
   ),
 }));
 
+jest.mock("../../app/components/spatial/SpatialComparisonPanel", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spatial-comparison-panel">Spatial comparison mock</div>,
+}));
+
 jest.mock("../../app/components/filter/TimeRangeFilter", () => ({
   __esModule: true,
   default: ({
@@ -87,6 +92,10 @@ describe("MapPage Component", () => {
       isLoading: true,
       error: null,
     }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("renders loading state correctly", async () => {
@@ -174,5 +183,40 @@ describe("MapPage Component", () => {
 
     // No data popup should appear
     expect(screen.getByText(/data tidak ditemukan/i)).toBeInTheDocument();
+  });
+
+  it("triggers manual refresh and passes incremented refreshToken to useLocations", async () => {
+    let lastRefresh = -1;
+    (useLocations as jest.Mock).mockImplementation((_filters, refreshToken) => {
+      lastRefresh = refreshToken;
+      return { data: [], isLoading: false, error: null };
+    });
+    render(<MapPage />);
+
+    expect(lastRefresh).toBe(0);
+    fireEvent.click(screen.getByTestId("auto-refresh-toggle-button"));
+    fireEvent.click(screen.getByTestId("manual-refresh"));
+    expect(lastRefresh).toBe(1);
+  });
+
+  it("auto refresh increments refresh token on interval", async () => {
+    jest.useFakeTimers();
+    let lastRefresh = -1;
+    (useLocations as jest.Mock).mockImplementation((_filters, refreshToken) => {
+      lastRefresh = refreshToken;
+      return { data: [], isLoading: false, error: null };
+    });
+
+    render(<MapPage />);
+    fireEvent.click(screen.getByTestId("auto-refresh-toggle-button"));
+    const toggle = screen.getByTestId("auto-refresh-toggle");
+    fireEvent.click(toggle);
+
+    await act(async () => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(lastRefresh).toBeGreaterThanOrEqual(1);
+    jest.useRealTimers();
   });
 });

--- a/__tests__/services/mapChartService.test.ts
+++ b/__tests__/services/mapChartService.test.ts
@@ -62,12 +62,12 @@ describe("MapChartService", () => {
   it("constructs MapChartManager with provided onError handler", () => {
     const onError = jest.fn();
     createService(onError);
-    expect(MapChartManagerMock).toHaveBeenCalledWith(onError);
+    expect(MapChartManagerMock).toHaveBeenCalledWith(onError, { syncStore: true });
   });
 
   it("constructs MapChartManager with undefined onError by default", () => {
     createService();
-    expect(MapChartManagerMock).toHaveBeenCalledWith(undefined);
+    expect(MapChartManagerMock).toHaveBeenCalledWith(undefined, { syncStore: true });
   });
 
   it("initializes the map via the manager", () => {

--- a/app/components/IndonesiaMap.tsx
+++ b/app/components/IndonesiaMap.tsx
@@ -10,6 +10,7 @@ import WarningButton from "./floating_buttons/WarningButton";
 import LocationButton from "./floating_buttons/LocationButton";
 import {MapButton} from "./floating_buttons/MapButton";
 import { useMapStore } from "../../store/store";
+import { MapChartService } from "../../services/mapChartService";
 
 interface IndonesiaMapProps {
   locations: MapLocation[];
@@ -24,6 +25,11 @@ interface IndonesiaMapProps {
   provincePrecipitationData: ProvinceData[];
   provinceSeverityData: ProvinceData[];
   timeFilter?: React.ReactNode;
+  mapId?: string;
+  shareStore?: boolean;
+  syncStore?: boolean;
+  onMapReady?: (service: MapChartService) => void;
+  showMapChrome?: boolean;
 }
 
 export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
@@ -37,8 +43,13 @@ export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
   width = "100vw",
   onError,
   timeFilter,
+  mapId = "chartdiv",
+  shareStore = true,
+  syncStore = true,
+  onMapReady,
+  showMapChrome = true,
 }) => {
-  const mapContainerId = "chartdiv";
+  const mapContainerId = mapId;
   const [showPermissionPopup, setShowPermissionPopup] = useState(false);
   const [locationError, setLocationError] = useState<LocationError | null>(null);
   const mapInitialized = useRef(false);
@@ -59,7 +70,8 @@ export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
     provincePrecipitationData,
     provinceSeverityData,
     onError,
-    mapInitialized.current
+    mapInitialized.current,
+    { shareStore, syncStore }
   );
   
   // Set mapInitialized to true after first render
@@ -67,8 +79,11 @@ export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
     /*istanbul ignore next*/
     if (!mapInitialized.current && mapService) {
       mapInitialized.current = true;
+      if (onMapReady) {
+        onMapReady(mapService);
+      }
     }
-  }, [mapService]);
+  }, [mapService, onMapReady]);
 
   // Fungsi untuk menangani zoom ke lokasi user
   const handleLocationSuccess = useCallback((latitude: number, longitude: number) => {
@@ -107,30 +122,34 @@ export const IndonesiaMap: React.FC<IndonesiaMapProps> = ({
       />
       
       {/* Changed from absolute to fixed positioning with greater top value to account for navbar */}
-      <div className="fixed top-[calc(5rem+1rem)] left-32 z-20 flex gap-3">
-        <LocationButton onClick={() => setShowPermissionPopup(true)} />
-        <WarningButton />
-      </div>
-      
-      {/* Changed from absolute to fixed positioning with greater top value to account for navbar */}
-      <div className="fixed top-[calc(5rem+1rem)] right-5 z-20 flex gap-2">
-        <DashboardButton />
-        <MapButton />
-      </div>
-      
-      {/* Popup izin lokasi */}
-      <LocationPermissionPopup
-        open={showPermissionPopup}
-        onClose={() => setShowPermissionPopup(false)}
-        onAllow={handleAllow}
-        onDeny={handleDeny}
-      />
-      <div className="fixed bottom-5 left-5 z-20 flex flex-col gap-3 md:flex-row md:items-end">
-        <div className="rounded-lg bg-black/60 p-2 text-lg font-bold text-white">
-          {`Points Visible: ${countSelectedPoints}`}
-        </div>
-        {timeFilter ? <div className="pointer-events-auto">{timeFilter}</div> : null}
-      </div>
+      {showMapChrome && (
+        <>
+          <div className="fixed top-[calc(5rem+1rem)] left-32 z-20 flex gap-3">
+            <LocationButton onClick={() => setShowPermissionPopup(true)} />
+            <WarningButton />
+          </div>
+          
+          {/* Changed from absolute to fixed positioning with greater top value to account for navbar */}
+          <div className="fixed top-[calc(5rem+1rem)] right-5 z-20 flex gap-2">
+            <DashboardButton />
+            <MapButton />
+          </div>
+          
+          {/* Popup izin lokasi */}
+          <LocationPermissionPopup
+            open={showPermissionPopup}
+            onClose={() => setShowPermissionPopup(false)}
+            onAllow={handleAllow}
+            onDeny={handleDeny}
+          />
+          <div className="fixed bottom-5 left-5 z-20 flex flex-col gap-3 md:flex-row md:items-end">
+            <div className="rounded-lg bg-black/60 p-2 text-lg font-bold text-white">
+              {`Points Visible: ${countSelectedPoints}`}
+            </div>
+            {timeFilter ? <div className="pointer-events-auto">{timeFilter}</div> : null}
+          </div>
+        </>
+      )}
       
       {/* Popup error lokasi */}
       {/*istanbul ignore next*/}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -12,6 +12,7 @@ import MultiSelectForm from "../components/filter/MultiSelectForm";
 import FilterButton from "../components/floating_buttons/FilterButton";
 import TimeRangeFilter from "../components/filter/TimeRangeFilter";
 import { FilterState } from "../../types";
+import SpatialComparisonPanel from "../components/spatial/SpatialComparisonPanel";
 
 const DEFAULT_FILTER_STATE: FilterState = {
   diseases: [],
@@ -25,7 +26,10 @@ const DEFAULT_FILTER_STATE: FilterState = {
 
 export default function MapPage() {
   const [filterState, setFilterState] = useState<FilterState>(DEFAULT_FILTER_STATE);
-  const { data: locations, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData, provinceSeverityData } = useLocations(filterState);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
+  const [autoRefreshInterval, setAutoRefreshInterval] = useState(30000);
+  const { data: locations, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData, provinceSeverityData } = useLocations(filterState, refreshToken);
   const { error: mapError, setError: setMapError, clearError } = useMapError();
   const [isEmptyData, setIsEmptyData] = useState(false);
   const [isFilterVisible, setIsFilterVisible] = useState(false);
@@ -56,9 +60,23 @@ export default function MapPage() {
     }
   }, [locations, isLoading, mapError, error]);
 
+  useEffect(() => {
+    if (!autoRefreshEnabled) {
+      return;
+    }
+    const timer = setInterval(() => {
+      setRefreshToken((prev) => prev + 1);
+    }, autoRefreshInterval);
+    return () => clearInterval(timer);
+  }, [autoRefreshEnabled, autoRefreshInterval]);
+
   const toggleFilterVisibility = () => {
     /* istanbul ignore next */
     setIsFilterVisible(prev => !prev);
+  };
+
+  const triggerManualRefresh = () => {
+    setRefreshToken((prev) => prev + 1);
   };
 
   if (isLoading) {
@@ -82,13 +100,48 @@ export default function MapPage() {
   return (
     <>
       <Navbar />
-      <div className="w-full h-[calc(100vh-5rem)] relative">
+      <div className="w-full min-h-[calc(100vh-5rem)] relative">
         {/* Changed from absolute to fixed positioning with greater top value to account for navbar */}
-        <div className="fixed top-[calc(5rem+1rem)] left-4 z-30">
-          <FilterButton 
+        <div className="fixed top-[calc(5rem+1rem)] left-4 z-30 flex flex-col gap-3">
+          <FilterButton
             onClick={toggleFilterVisibility}
             isActive={isFilterVisible}
           />
+          <div className="bg-white/90 shadow-lg rounded-lg p-3 max-w-xs text-sm space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-semibold">Auto-refresh</span>
+              <label className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={autoRefreshEnabled}
+                  onChange={(e) => setAutoRefreshEnabled(e.target.checked)}
+                  data-testid="auto-refresh-toggle"
+                />
+                Aktif
+              </label>
+            </div>
+            <label className="flex items-center gap-2 text-xs">
+              <span>Interval</span>
+              <select
+                className="border rounded p-1 flex-1"
+                value={autoRefreshInterval}
+                onChange={(e) => setAutoRefreshInterval(Number(e.target.value))}
+                data-testid="auto-refresh-interval"
+              >
+                <option value={15000}>15 detik</option>
+                <option value={30000}>30 detik</option>
+                <option value={60000}>60 detik</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={triggerManualRefresh}
+              className="w-full bg-blue-500 text-white py-1 rounded-md"
+              data-testid="manual-refresh"
+            >
+              Muat ulang peta
+            </button>
+          </div>
         </div>
 
         {/* Conditionally render the filter form */}
@@ -113,7 +166,7 @@ export default function MapPage() {
         )}
         
         {/* Always render the map container */}
-        <div className="relative w-full h-full">
+        <div className="relative w-full h-[calc(100vh-6rem)]">
           {isLoading && ( 
             <div className="absolute inset-0 bg-white bg-opacity-70 flex items-center justify-center z-10">
               <div className="flex flex-col items-center">
@@ -155,6 +208,17 @@ export default function MapPage() {
                 }}
               />
             }
+          />
+        </div>
+        <div className="w-full px-4 py-6 bg-gray-50">
+          <SpatialComparisonPanel
+            baseFilters={filterState}
+            refreshToken={refreshToken}
+            onError={(message) => setMapError(message)}
+            provinceHumidityData={provinceHumidityData}
+            provincePrecipitationData={provincePrecipitationData}
+            provinceSeverityData={provinceSeverityData}
+            provinceTemperatureData={provinceTemperatureData}
           />
         </div>
       </div>


### PR DESCRIPTION
This pull request prepares the frontend for the spatial comparison feature on the map page and improves refresh behavior for map data. I add a new SpatialComparisonPanel that sits under the main map and lets users pick two or more regions, pick a metric such as humidity or precipitation, and view comparison cards. When fewer than two regions are selected the panel shows simple guidance in Bahasa. The panel uses a dedicated hook so that API errors and loading states are handled in a clear way and surfaced to the user.

I introduce a new hook named useSpatialComparisons that calls the map API with the selected regions and base filters. The hook exposes comparisons, loading flag, error, and last updated time and it refetches when the refresh token changes. I also extend useLocations so that it can refetch when a refresh token changes, and I add tests to prove that refetch happens both for manual refresh and for auto refresh intervals.

On the map page I wire the new refresh token and add an auto refresh control next to the filter button. Users can toggle auto refresh, choose an interval of fifteen thirty or sixty seconds, and also trigger a manual reload. The map component now accepts a map id, sharing and sync options for the store, a flag to hide or show map chrome, and an onMapReady callback. The MapChartService is created with sync store enabled so that multiple maps can share consistent state. I update related tests for the map page, map chart service, location hook, and the new spatial comparison hook and panel so that all new behavior is covered.