### PR TITLE
Pbi 14 spatial comparison

### DIFF
--- a/__tests__/expert-bulk-upload/page.test.tsx
+++ b/__tests__/expert-bulk-upload/page.test.tsx
@@ -82,7 +82,7 @@ describe('CuratorBulkUploadPage (expert-bulk-upload)', () => {
   });
 
   test('shows access denied for authenticated non-EXP_USER', async () => {
-    mockUseAuth.mockReturnValue({ user: { role: 'ADMIN' } });
+    mockUseAuth.mockReturnValue({ user: { role: 'USER' } });
 
     const Page = require('../../app/expert-bulk-upload/page').default;
     render(<Page />);

--- a/__tests__/expert-data-management/page.test.tsx
+++ b/__tests__/expert-data-management/page.test.tsx
@@ -21,12 +21,14 @@ jest.mock("next/navigation", () => ({
   }),
 }));
 
-jest.mock("../../app/components/Navbar", () => () => (
-  <div data-testid="mock-navbar">Navbar</div>
-));
-jest.mock("../../app/components/Footer", () => () => (
-  <div data-testid="mock-footer">Footer</div>
-));
+jest.mock("../../app/components/Navbar", () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-navbar">Navbar</div>,
+}));
+jest.mock("../../app/components/Footer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="mock-footer">Footer</div>,
+}));
 
 const mockUseAuth = jest.fn(() => ({ user: { role: "EXP_USER" } }));
 jest.mock("../../app/auth/hooks/useAuth", () => ({

--- a/__tests__/expert-data-management/view/page.view.test.tsx
+++ b/__tests__/expert-data-management/view/page.view.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import ExpertViewPage from "../../../app/expert-data-management/view/page";
 import "@testing-library/jest-dom";
+import React from "react";
 
 // --- Mock router and search params ---
 const mockBack = jest.fn();
@@ -14,8 +15,17 @@ jest.mock("next/navigation", () => ({
 }));
 
 // --- Mock layout components ---
-jest.mock("../../../app/components/Navbar", () => () => <div data-testid="navbar">Navbar</div>);
-jest.mock("../../../app/components/Footer", () => () => <div data-testid="footer">Footer</div>);
+jest.mock("../../../app/components/Navbar", () => ({
+  __esModule: true,
+  default: () => <div data-testid="navbar">Navbar</div>,
+}));
+jest.mock("../../../app/components/Footer", () => ({
+  __esModule: true,
+  default: () => <div data-testid="footer">Footer</div>,
+}));
+jest.mock("../../../app/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { role: "EXP_USER" } }),
+}));
 
 // --- Mock global fetch ---
 global.fetch = jest.fn();

--- a/app/components/dashboard/DownloadButton.tsx
+++ b/app/components/dashboard/DownloadButton.tsx
@@ -73,7 +73,7 @@ const DownloadButton: React.FC<DownloadButtonProps> = ({
   >(null);
   const notificationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const imageLabel = imgLabel ?? label ?? "Download IMG";
+  const imageLabel = imgLabel ?? label ?? "Unduh gambar";
   const showCsvButton = Boolean(csvExporter);
   const effectiveCsvFilename = ensureCsvExtension(csvFilename ?? filename);
 

--- a/app/components/dashboard/sumberBerita/PortalBarChart.tsx
+++ b/app/components/dashboard/sumberBerita/PortalBarChart.tsx
@@ -258,13 +258,15 @@ const PortalBarChart: React.FC<PortalBarChartProps> = ({
           stroke: null
         });
 
-        series.columns.template.adapters.add("tooltipText", (text: string | undefined, target: any) => {
-          const custom = target?.dataItem?.dataContext?.tooltipText;
-          if (typeof custom === "string" && custom.trim().length > 0) {
-            return custom;
-          }
-          return text;
-        });
+        if (series?.columns?.template?.adapters) {
+          series.columns.template.adapters.add("tooltipText", (text: string | undefined, target: any) => {
+            const custom = target?.dataItem?.dataContext?.tooltipText;
+            if (typeof custom === "string" && custom.trim().length > 0) {
+              return custom;
+            }
+            return text;
+          });
+        }
 
         // Prepare series data using the utility function
         const seriesData = prepareSeriesData(chartData);

--- a/app/components/filter/MultiSelectForm.tsx
+++ b/app/components/filter/MultiSelectForm.tsx
@@ -93,6 +93,16 @@ export default function MultiSelectForm({
     },
     news: [],
   });
+
+  // Preselect batch if provided so mocked selects pick it up even before options arrive
+  useEffect(() => {
+    if (initialFilterState?.batch) {
+      setSelectedBatch({
+        value: initialFilterState.batch,
+        label: initialFilterState.batch,
+      });
+    }
+  }, [initialFilterState?.batch]);
   
   const handleReset = () => {
     setSelectedDiseases([]);
@@ -176,14 +186,13 @@ export default function MultiSelectForm({
 
         if (!isActive) return;
 
-        if (
-          initialFilterState?.batch &&
-          !batchSelectOptions.some((option) => option.value === initialFilterState.batch)
-        ) {
-          batchSelectOptions = [
-            ...batchSelectOptions,
-            { value: initialFilterState.batch, label: initialFilterState.batch },
-          ];
+        if (initialFilterState?.batch) {
+          if (!batchSelectOptions.some((option) => option.value === initialFilterState.batch)) {
+            batchSelectOptions = [
+              ...batchSelectOptions,
+              { value: initialFilterState.batch, label: initialFilterState.batch },
+            ];
+          }
         }
 
         setBatchOptions(batchSelectOptions);

--- a/app/components/spatial/SpatialComparisonPanel.tsx
+++ b/app/components/spatial/SpatialComparisonPanel.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Select, { components, MultiValue } from "react-select";
+import { IndonesiaMap } from "../IndonesiaMap";
+import { useSpatialComparisons, SpatialComparisonRegion } from "../../../hooks/useSpatialComparisons";
+import { FilterState, ProvinceData, SpatialComparisonItem } from "../../../types";
+import { MapChartService } from "../../../services/mapChartService";
+
+interface SpatialComparisonPanelProps {
+  baseFilters: FilterState;
+  refreshToken: number;
+  onError: (message: string) => void;
+  provinceHumidityData: ProvinceData[];
+  provinceTemperatureData: ProvinceData[];
+  provincePrecipitationData: ProvinceData[];
+  provinceSeverityData: ProvinceData[];
+  initialRegions?: SpatialComparisonRegion[];
+  maxRegions?: number;
+  overlayMode?: boolean;
+  onClose?: () => void;
+}
+
+type MetricOption = "cases" | "precipitation" | "humidity" | "temperature" | "severity";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const Group = (props: any) => (
+  <div>
+    <components.Group {...props}>
+      <div className="px-2 py-1 bg-gray-100 text-sm font-medium">
+        {props.label}
+      </div>
+      {props.children}
+    </components.Group>
+  </div>
+);
+
+const formatDate = (value: Date | string | null | undefined) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString("id-ID");
+};
+
+const ComparisonCard = ({
+  comparison,
+  index,
+  provinceHumidityData,
+  provinceTemperatureData,
+  provincePrecipitationData,
+  provinceSeverityData,
+  onError,
+  lastUpdated,
+}: {
+  comparison: SpatialComparisonItem;
+  index: number;
+  provinceHumidityData: ProvinceData[];
+  provinceTemperatureData: ProvinceData[];
+  provincePrecipitationData: ProvinceData[];
+  provinceSeverityData: ProvinceData[];
+  onError: (message: string) => void;
+  lastUpdated: Date | null;
+}) => {
+  const [selectedMetric, setSelectedMetric] = useState<MetricOption>("cases");
+  const [mapService, setMapService] = useState<MapChartService | null>(null);
+
+  const applyMetric = (metric: MetricOption, service?: MapChartService | null) => {
+    if (!service) return;
+    switch (metric) {
+      case "precipitation":
+        service.showPrecipitationLayer();
+        break;
+      case "humidity":
+        service.showHumidityLayer();
+        break;
+      case "temperature":
+        service.showTemperatureLayer();
+        break;
+      case "severity":
+        service.showSeverityLayer();
+        break;
+      default:
+        service.hideAllLayers();
+    }
+  };
+
+  useEffect(() => {
+    applyMetric(selectedMetric, mapService);
+  }, [selectedMetric, mapService]);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-3 space-y-3" data-testid="comparison-card">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs text-gray-500">Wilayah {index + 1}</p>
+          <h3 className="text-lg font-semibold text-gray-900">{comparison.label}</h3>
+          <p className="text-sm text-gray-600">{comparison.count} titik kasus</p>
+        </div>
+        <div className="text-right text-xs text-gray-500">
+          <p>Terakhir diperbarui</p>
+          <p className="font-semibold">{lastUpdated ? lastUpdated.toLocaleTimeString("id-ID") : "-"}</p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <label className="text-xs font-semibold text-gray-700">Layer metrik</label>
+        <select
+          className="border rounded px-2 py-1 text-sm flex-1"
+          value={selectedMetric}
+          onChange={(e) => setSelectedMetric(e.target.value as MetricOption)}
+          data-testid="metric-select"
+        >
+          <option value="cases">Kasus</option>
+          <option value="severity">Keparahan</option>
+          <option value="temperature">Temperatur</option>
+          <option value="humidity">Kelembaban</option>
+          <option value="precipitation">Curah Hujan</option>
+        </select>
+      </div>
+      <div className="h-80 rounded-md overflow-hidden border border-gray-200">
+        <IndonesiaMap
+          mapId={`comparison-map-${index}`}
+          locations={comparison.locations}
+          provinceHumidityData={provinceHumidityData}
+          provincePrecipitationData={provincePrecipitationData}
+          provinceTemperatureData={provinceTemperatureData}
+          provinceSeverityData={provinceSeverityData}
+          config={{ zoomLevel: 2, centerPoint: { longitude: 113.9213, latitude: 0.7893 } }}
+          width="100%"
+          height="320px"
+          onError={onError}
+          shareStore={false}
+          syncStore={false}
+          showMapChrome={false}
+          onMapReady={(service) => {
+            setMapService(service);
+            applyMetric(selectedMetric, service);
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default function SpatialComparisonPanel({
+  baseFilters,
+  refreshToken,
+  onError,
+  provinceHumidityData,
+  provinceTemperatureData,
+  provincePrecipitationData,
+  provinceSeverityData,
+  initialRegions = [],
+  maxRegions,
+  overlayMode = false,
+  onClose,
+}: SpatialComparisonPanelProps) {
+  const [regionOptions, setRegionOptions] = useState<SpatialComparisonRegion[]>([]);
+  const [selectedRegions, setSelectedRegions] = useState<SpatialComparisonRegion[]>(initialRegions);
+  const [regionA, setRegionA] = useState<SpatialComparisonRegion | null>(initialRegions[0] || null);
+  const [regionB, setRegionB] = useState<SpatialComparisonRegion | null>(initialRegions[1] || null);
+  const [isLoadingFilters, setIsLoadingFilters] = useState(false);
+  const [filtersError, setFiltersError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedRegions(initialRegions);
+    setRegionA(initialRegions[0] || null);
+    setRegionB(initialRegions[1] || null);
+  }, [initialRegions]);
+
+  const reconcileOption = (current: SpatialComparisonRegion | null) => {
+    if (!current) return null;
+    const found = regionOptions.find((opt) => opt.value === current.value);
+    return found || current;
+  };
+
+  const findOption = (option: SpatialComparisonRegion | null) => {
+    if (!option) return null;
+    const existing = regionOptions.find((opt) => opt.value === option.value);
+    return existing || option;
+  };
+
+  useEffect(() => {
+    setRegionA((prev) => reconcileOption(prev));
+    setRegionB((prev) => reconcileOption(prev));
+  }, [regionOptions]);
+
+  useEffect(() => {
+    let isActive = true;
+    const fetchOptions = async () => {
+      setIsLoadingFilters(true);
+      try {
+        const response = await fetch(`${API_BASE_URL}/api/filters/`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          mode: "cors",
+        });
+
+        if (!response.ok) {
+          throw new Error("Gagal memuat daftar wilayah");
+        }
+
+        const payload = await response.json();
+        if (!isActive) return;
+
+        const normalizeOption = (item: any, scope: "province" | "city"): SpatialComparisonRegion => {
+          const value = item?.value || item?.label || item?.name || "";
+          const label = item?.label || item?.name || item?.value || value;
+          return { value, label, scope };
+        };
+
+        const provinces: SpatialComparisonRegion[] = (payload.data?.locations?.provinces || [])
+          .map((item: any) => normalizeOption(item, "province"))
+          .filter((opt: SpatialComparisonRegion) => Boolean(opt.value));
+        const cities: SpatialComparisonRegion[] = (payload.data?.locations?.cities || [])
+          .map((item: any) => normalizeOption(item, "city"))
+          .filter((opt: SpatialComparisonRegion) => Boolean(opt.value));
+        setRegionOptions([...provinces, ...cities]);
+        setFiltersError(null);
+      } catch (err) {
+        console.error("Failed to fetch spatial comparison filters", err);
+        if (!isActive) return;
+        const message = err instanceof Error ? err.message : "Gagal memuat daftar wilayah";
+        setFiltersError(message);
+        onError(message);
+      } finally {
+        if (isActive) {
+          setIsLoadingFilters(false);
+        }
+      }
+    };
+
+    fetchOptions();
+
+    return () => {
+      isActive = false;
+    };
+  }, [onError]);
+
+  const groupedOptions = useMemo(
+    () => [
+      {
+        label: "Provinsi",
+        options: regionOptions.filter((option) => option.scope === "province"),
+      },
+      {
+        label: "Kota/Kabupaten",
+        options: regionOptions.filter((option) => option.scope === "city"),
+      },
+    ],
+    [regionOptions]
+  );
+
+  const {
+    comparisons,
+    isLoading,
+    error: comparisonError,
+    lastUpdated,
+  } = useSpatialComparisons({
+    regions: selectedRegions,
+    baseFilters,
+    refreshToken,
+    enabled: selectedRegions.length >= 2,
+  });
+
+  const filterSummary = useMemo(() => {
+    const summary: string[] = [];
+    if (baseFilters.diseases.length) summary.push(`Penyakit: ${baseFilters.diseases.join(", ")}`);
+    if (baseFilters.portals.length) summary.push(`Portal: ${baseFilters.portals.join(", ")}`);
+    if (baseFilters.level_of_alertness) summary.push(`Kewaspadaan: ${baseFilters.level_of_alertness}`);
+    const start = formatDate(baseFilters.start_date);
+    const end = formatDate(baseFilters.end_date);
+    if (start || end) summary.push(`Rentang: ${start || "-"} - ${end || "-"}`);
+    if (baseFilters.batch) summary.push(`Batch: ${baseFilters.batch}`);
+    return summary.length ? summary.join(" • ") : "Tidak ada filter tambahan";
+  }, [baseFilters]);
+
+  const handleApplySelection = () => {
+    const regionsToApply = [regionA, regionB].filter((item): item is SpatialComparisonRegion => Boolean(item && item.value));
+    const limited = maxRegions ? regionsToApply.slice(0, maxRegions) : regionsToApply;
+    setSelectedRegions(limited);
+  };
+  const handleResetSelection = () => {
+    setRegionA(null);
+    setRegionB(null);
+    setSelectedRegions([]);
+  };
+
+  const statusMessage = (() => {
+    if (comparisonError) {
+      return comparisonError.message;
+    }
+    if (filtersError) {
+      return filtersError;
+    }
+    if (isLoadingFilters) {
+      return "Memuat daftar wilayah...";
+    }
+    if (selectedRegions.length < 2) {
+      return "Pilih minimal dua wilayah untuk membandingkan peta secara berdampingan.";
+    }
+    if (isLoading) {
+      return "Menyiapkan perbandingan spasial...";
+    }
+    if (!comparisons.length) {
+      return "Tidak ada data untuk filter yang dipilih.";
+    }
+    return null;
+  })();
+
+  return (
+    <section className={`max-w-6xl ${overlayMode ? "" : "mx-auto"} space-y-4`} data-testid="spatial-comparison-panel">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-blue-700 font-semibold">Perbandingan Spasial</p>
+          <h2 className="text-2xl font-bold text-gray-900">Render peta berdampingan</h2>
+          <p className="text-sm text-gray-600">Filter global tersinkron otomatis ke seluruh peta.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-xs text-gray-600 bg-white shadow rounded-lg p-3">
+            <p className="font-semibold text-gray-800">Ringkasan filter</p>
+            <p>{filterSummary}</p>
+          </div>
+          {onClose ? (
+            <button
+              type="button"
+              className="text-xs border rounded-md px-3 py-2 bg-white shadow"
+              onClick={onClose}
+              data-testid="close-spatial-panel"
+            >
+              Tutup
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="bg-white shadow rounded-lg p-4 space-y-3">
+        <div className="flex flex-col md:flex-row gap-3 md:items-end">
+          <div className="flex-1 min-w-[260px]">
+            <label className="block text-sm font-medium text-gray-700 mb-1">Wilayah 1</label>
+            <Select
+              isDisabled={isLoadingFilters}
+              options={groupedOptions}
+              value={findOption(regionA)}
+              onChange={(val) => setRegionA(findOption(val as SpatialComparisonRegion))}
+              className="text-sm"
+              components={{ Group }}
+              placeholder="Pilih provinsi atau kota"
+              data-testid="region-a-select"
+            />
+          </div>
+          <div className="flex-1 min-w-[260px]">
+            <label className="block text-sm font-medium text-gray-700 mb-1">Wilayah 2</label>
+            <Select
+              isDisabled={isLoadingFilters}
+              options={groupedOptions}
+              value={findOption(regionB)}
+              onChange={(val) => setRegionB(findOption(val as SpatialComparisonRegion))}
+              className="text-sm"
+              components={{ Group }}
+              placeholder="Pilih provinsi atau kota"
+              data-testid="region-b-select"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
+              onClick={handleResetSelection}
+              data-testid="reset-region-selection"
+            >
+              Reset wilayah
+            </button>
+            <button
+              type="button"
+              className="bg-blue-600 text-white rounded-md px-3 py-2 text-sm hover:bg-blue-700"
+              onClick={handleApplySelection}
+              data-testid="refresh-comparison"
+            >
+              Sinkronkan filter
+            </button>
+          </div>
+        </div>
+        {statusMessage && (
+          <div className="text-sm text-gray-700 bg-gray-100 border border-gray-200 rounded-md p-3" data-testid="comparison-status">
+            {statusMessage}
+          </div>
+        )}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {comparisons.map((item, idx) => (
+            <ComparisonCard
+              key={`${item.label}-${idx}`}
+              comparison={item}
+              index={idx}
+              provinceHumidityData={provinceHumidityData}
+              provinceTemperatureData={provinceTemperatureData}
+              provincePrecipitationData={provincePrecipitationData}
+              provinceSeverityData={provinceSeverityData}
+              onError={onError}
+              lastUpdated={lastUpdated}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/expert-data-management/page.tsx
+++ b/app/expert-data-management/page.tsx
@@ -25,6 +25,7 @@ type PageProps = {
 };
 
 function getToken(): string | null {
+  if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem("user");
     if (raw) {
@@ -32,11 +33,17 @@ function getToken(): string | null {
       if (parsed?.access_token) return String(parsed.access_token);
       if (parsed?.token) return String(parsed.token);
     }
-    const t = window.localStorage.getItem("access_token") || window.localStorage.getItem("token");
-    return t || null;
-  } catch {
-    return null;
+  } catch {}
+  const keys = ["access_token", "token", "accessToken", "jwt"];
+  for (const key of keys) {
+    const v = window.localStorage.getItem(key);
+    if (v) return v;
   }
+  try {
+    const m = document.cookie.match(/(?:^|;\\s*)access_token=([^;]+)/);
+    if (m) return decodeURIComponent(m[1]);
+  } catch {}
+  return null;
 }
 
 function getTokenForDelete(): string | null {

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -29,6 +29,8 @@ export default function MapPage() {
   const [refreshToken, setRefreshToken] = useState(0);
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(false);
   const [autoRefreshInterval, setAutoRefreshInterval] = useState(30000);
+  const [showAutoRefreshPanel, setShowAutoRefreshPanel] = useState(false);
+  const [showSpatialComparison, setShowSpatialComparison] = useState(false);
   const { data: locations, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData, provinceSeverityData } = useLocations(filterState, refreshToken);
   const { error: mapError, setError: setMapError, clearError } = useMapError();
   const [isEmptyData, setIsEmptyData] = useState(false);
@@ -101,47 +103,12 @@ export default function MapPage() {
     <>
       <Navbar />
       <div className="w-full min-h-[calc(100vh-5rem)] relative">
-        {/* Changed from absolute to fixed positioning with greater top value to account for navbar */}
-        <div className="fixed top-[calc(5rem+1rem)] left-4 z-30 flex flex-col gap-3">
+        {/* Filter trigger */}
+        <div className="fixed top-[calc(5rem+1rem)] left-4 z-30">
           <FilterButton
             onClick={toggleFilterVisibility}
             isActive={isFilterVisible}
           />
-          <div className="bg-white/90 shadow-lg rounded-lg p-3 max-w-xs text-sm space-y-2">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-semibold">Auto-refresh</span>
-              <label className="flex items-center gap-2 text-xs">
-                <input
-                  type="checkbox"
-                  checked={autoRefreshEnabled}
-                  onChange={(e) => setAutoRefreshEnabled(e.target.checked)}
-                  data-testid="auto-refresh-toggle"
-                />
-                Aktif
-              </label>
-            </div>
-            <label className="flex items-center gap-2 text-xs">
-              <span>Interval</span>
-              <select
-                className="border rounded p-1 flex-1"
-                value={autoRefreshInterval}
-                onChange={(e) => setAutoRefreshInterval(Number(e.target.value))}
-                data-testid="auto-refresh-interval"
-              >
-                <option value={15000}>15 detik</option>
-                <option value={30000}>30 detik</option>
-                <option value={60000}>60 detik</option>
-              </select>
-            </label>
-            <button
-              type="button"
-              onClick={triggerManualRefresh}
-              className="w-full bg-blue-500 text-white py-1 rounded-md"
-              data-testid="manual-refresh"
-            >
-              Muat ulang peta
-            </button>
-          </div>
         </div>
 
         {/* Conditionally render the filter form */}
@@ -209,17 +176,84 @@ export default function MapPage() {
               />
             }
           />
-        </div>
-        <div className="w-full px-4 py-6 bg-gray-50">
-          <SpatialComparisonPanel
-            baseFilters={filterState}
-            refreshToken={refreshToken}
-            onError={(message) => setMapError(message)}
-            provinceHumidityData={provinceHumidityData}
-            provincePrecipitationData={provincePrecipitationData}
-            provinceSeverityData={provinceSeverityData}
-            provinceTemperatureData={provinceTemperatureData}
-          />
+          {/* Spatial comparison toggle */}
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-30">
+            <button
+              type="button"
+              className="bg-white/90 shadow rounded-full px-4 py-2 text-sm font-semibold border"
+              onClick={() => setShowSpatialComparison((prev) => !prev)}
+              data-testid="spatial-toggle"
+            >
+              {showSpatialComparison ? "Tutup Peta Berdampingan" : "Perbandingan Spasial"}
+            </button>
+          </div>
+          {/* Spatial comparison overlay */}
+          {showSpatialComparison ? (
+            <div className="absolute inset-x-4 top-16 z-30 pointer-events-auto">
+              <div className="bg-white shadow-2xl rounded-xl p-4 max-h-[70vh] overflow-y-auto border border-gray-200">
+                <SpatialComparisonPanel
+                  baseFilters={filterState}
+                  refreshToken={refreshToken}
+                  onError={(message) => setMapError(message)}
+                  provinceHumidityData={provinceHumidityData}
+                  provincePrecipitationData={provincePrecipitationData}
+                  provinceSeverityData={provinceSeverityData}
+                  provinceTemperatureData={provinceTemperatureData}
+                  maxRegions={2}
+                  overlayMode
+                  onClose={() => setShowSpatialComparison(false)}
+                />
+              </div>
+            </div>
+          ) : null}
+          {/* Auto-refresh toggle near bottom-left */}
+          <div className="absolute bottom-16 left-4 z-30 pointer-events-auto">
+            <button
+              type="button"
+              className="bg-white/90 shadow rounded-md px-3 py-2 text-sm font-semibold border"
+              onClick={() => setShowAutoRefreshPanel((prev) => !prev)}
+              data-testid="auto-refresh-toggle-button"
+            >
+              {showAutoRefreshPanel ? "Tutup Auto Refresh" : "Auto Refresh"}
+            </button>
+            {showAutoRefreshPanel ? (
+              <div className="mt-2 bg-white/95 shadow-lg rounded-lg p-3 w-64 text-sm space-y-2 border border-gray-200">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-semibold">Auto-refresh</span>
+                  <label className="flex items-center gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={autoRefreshEnabled}
+                      onChange={(e) => setAutoRefreshEnabled(e.target.checked)}
+                      data-testid="auto-refresh-toggle"
+                    />
+                    Aktif
+                  </label>
+                </div>
+                <label className="flex items-center gap-2 text-xs">
+                  <span>Interval</span>
+                  <select
+                    className="border rounded p-1 flex-1"
+                    value={autoRefreshInterval}
+                    onChange={(e) => setAutoRefreshInterval(Number(e.target.value))}
+                    data-testid="auto-refresh-interval"
+                  >
+                    <option value={15000}>15 detik</option>
+                    <option value={30000}>30 detik</option>
+                    <option value={60000}>60 detik</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={triggerManualRefresh}
+                  className="w-full bg-blue-500 text-white py-1 rounded-md"
+                  data-testid="manual-refresh"
+                >
+                  Muat ulang peta
+                </button>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </>

--- a/hooks/useIndonesiaMap.ts
+++ b/hooks/useIndonesiaMap.ts
@@ -12,12 +12,18 @@ export function useIndonesiaMap(
   provincePrecipitationData: ProvinceData[],
   provinceSeverityData: ProvinceData[],
   onError: (message: string) => void,
-  initialized = false
+  initialized = false,
+  options?: {
+    shareStore?: boolean;
+    syncStore?: boolean;
+  }
 ) {
   const mapServiceRef = useRef<MapChartService | null>(null);
   const [mapService, setMapService] = useState<MapChartService | null>(null);
   const locationsRef = useRef<MapLocation[]>(locations);
   const setMapServiceStore = useMapStore((state) => state.setMapService);
+  const shareStore = options?.shareStore ?? true;
+  const syncStore = options?.syncStore ?? true;
   
   // Set up the map once
   useEffect(() => {
@@ -27,7 +33,7 @@ export function useIndonesiaMap(
       return;
     }
     
-    const service = new MapChartService(onError);
+    const service = new MapChartService(onError, { syncStore });
     
     try {
       service.initialize(containerId, config);
@@ -38,7 +44,9 @@ export function useIndonesiaMap(
       service.populateProvinceSeverityData(provinceSeverityData);
       mapServiceRef.current = service;
       setMapService(service);
-      setMapServiceStore(service); // Update the Zustand store
+      if (shareStore) {
+        setMapServiceStore(service); // Update the Zustand store
+      }
     } catch (error) {
       console.error("Failed to initialize map:", error);
     }
@@ -48,10 +56,12 @@ export function useIndonesiaMap(
       if (!initialized && mapServiceRef.current) {
         mapServiceRef.current.dispose();
         mapServiceRef.current = null;
-        setMapServiceStore(null); // Clear the service from store on cleanup
+        if (shareStore) {
+          setMapServiceStore(null); // Clear the service from store on cleanup
+        }
       }
     };
-  }, [containerId, config, initialized, onError, setMapServiceStore]);
+  }, [containerId, config, initialized, onError, setMapServiceStore, shareStore, syncStore]);
   
   // Update locations when they change, without reinitializing the map
   useEffect(() => {

--- a/hooks/useLocations.ts
+++ b/hooks/useLocations.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { MapLocation, FilterState } from '../types';
 import { mapApi } from '../services/api';
 
-const serializeFilterState = (state: FilterState): string => {
+const serializeFilterState = (state: FilterState, refreshToken = 0): string => {
   const normalizeDate = (value: FilterState["start_date"]) => {
     if (!value) {
       return null;
@@ -17,10 +17,11 @@ const serializeFilterState = (state: FilterState): string => {
     ...state,
     start_date: normalizeDate(state.start_date),
     end_date: normalizeDate(state.end_date),
+    __refreshToken: refreshToken,
   });
 };
 
-export const useLocations = (filterState: FilterState) => {
+export const useLocations = (filterState: FilterState, refreshToken = 0) => {
   const [data, setData] = useState<MapLocation[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -94,7 +95,7 @@ export const useLocations = (filterState: FilterState) => {
   };
 
   useEffect(() => {
-    const serializedFilter = serializeFilterState(filterState);
+    const serializedFilter = serializeFilterState(filterState, refreshToken);
 
     // Skip re-fetching when filters are effectively unchanged
     if (lastSerializedFilterRef.current === serializedFilter) {
@@ -194,7 +195,7 @@ export const useLocations = (filterState: FilterState) => {
     return () => {
       isCancelled = true;
     };
-  }, [filterState]);
+  }, [filterState, refreshToken]);
 
   return { data, isLoading, error, provinceHumidityData, provinceTemperatureData, provincePrecipitationData, provinceSeverityData };
 };

--- a/hooks/useSpatialComparisons.ts
+++ b/hooks/useSpatialComparisons.ts
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from "react";
+import { mapApi } from "../services/api";
+import { FilterState, MapLocation, SpatialComparisonItem, SpatialComparisonRegion } from "../types";
+
+interface UseSpatialComparisonsParams {
+  regions: SpatialComparisonRegion[];
+  baseFilters: FilterState;
+  enabled?: boolean;
+  refreshToken?: number;
+}
+
+const normalizeDate = (value: FilterState["start_date"]) => {
+  if (!value) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return value;
+};
+
+const normalizeFilter = (filters: FilterState) => ({
+  ...filters,
+  start_date: normalizeDate(filters.start_date),
+  end_date: normalizeDate(filters.end_date),
+  batch: filters.batch ?? null,
+});
+
+export const useSpatialComparisons = ({
+  regions,
+  baseFilters,
+  enabled = true,
+  refreshToken = 0,
+}: UseSpatialComparisonsParams) => {
+  const [comparisons, setComparisons] = useState<SpatialComparisonItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const normalizedFilter = useMemo(() => normalizeFilter(baseFilters), [baseFilters]);
+  const filterSignature = useMemo(
+    () => JSON.stringify(normalizedFilter),
+    [normalizedFilter]
+  );
+  const regionSignature = useMemo(
+    () => JSON.stringify(regions.map((region) => ({
+      value: region.value,
+      label: region.label,
+      scope: region.scope || null,
+    }))),
+    [regions]
+  );
+  const isActive = enabled && regions.length > 0;
+
+  useEffect(() => {
+    if (!isActive) {
+      setComparisons([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    const payload = {
+      regions: regions.map((region, index) => ({
+        label: region.label || region.value || `Region ${index + 1}`,
+        filters: {
+          ...normalizedFilter,
+          locations: {
+            provinces: [region.value],
+            cities: [region.value],
+          },
+        },
+      })),
+    };
+
+    mapApi
+      .getSpatialComparisons(payload)
+      .then((response) => {
+        if (cancelled) return;
+        const payloadComparisons: SpatialComparisonItem[] = response?.comparisons || [];
+        setComparisons(payloadComparisons);
+        setLastUpdated(new Date());
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error("Failed to fetch spatial comparisons"));
+        setComparisons([]);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filterSignature, regionSignature, refreshToken, isActive, normalizedFilter, regions]);
+
+  return {
+    comparisons,
+    isLoading,
+    error,
+    lastUpdated,
+  };
+};
+
+export type { SpatialComparisonRegion, SpatialComparisonItem, MapLocation };

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,4 +1,4 @@
-import { MapLocation, FilterState, ProvinceData, ExpertBatch } from "../types";
+import { MapLocation, FilterState, ProvinceData, ExpertBatch, SpatialComparisonResponse } from "../types";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
@@ -57,6 +57,34 @@ export const mapApi = {
       return await response.json();
     } catch (error) {
       console.error('Error fetching filtered locations:', error);
+      throw error;
+    }
+  },
+
+  async getSpatialComparisons(payload: {
+    regions: Array<Record<string, unknown>>;
+  }): Promise<SpatialComparisonResponse> {
+    try {
+      const accessToken = typeof localStorage !== "undefined" ? localStorage.getItem("accessToken") : null;
+      const response = await fetch(`${API_BASE_URL}/cases/spatial-comparisons/`, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-api-key": String(API_KEY),
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error("Error fetching spatial comparisons:", error);
       throw error;
     }
   },

--- a/services/map/MapChartManager.ts
+++ b/services/map/MapChartManager.ts
@@ -19,9 +19,16 @@ export class MapChartManager {
   private locations: MapLocation[] | null = null;
   private _countSelectedPoints: number = 0;
   private readonly onError: ((message: string) => void) | null = null;
+  private readonly syncStore: boolean;
 
-  constructor(onError?: (message: string) => void) {
+  constructor(
+    onError?: (message: string) => void,
+    options?: {
+      syncStore?: boolean;
+    }
+  ) {
     this.onError = onError || null;
+    this.syncStore = options?.syncStore ?? true;
   }
 
   /**
@@ -195,7 +202,9 @@ export class MapChartManager {
   private set countSelectedPoints(value: number) {
     this._countSelectedPoints = value;
     // Update Zustand store
-    useMapStore.getState().setCountSelectedPoints(value);
+    if (this.syncStore) {
+      useMapStore.getState().setCountSelectedPoints(value);
+    }
   }
 
   /**

--- a/services/mapChartService.ts
+++ b/services/mapChartService.ts
@@ -8,8 +8,15 @@ import { MapChartManager } from "./map";
 export class MapChartService {
   private readonly mapManager: MapChartManager;
 
-  constructor(onError?: (message: string) => void) {
-    this.mapManager = new MapChartManager(onError);
+  constructor(
+    onError?: (message: string) => void,
+    options?: {
+      syncStore?: boolean;
+    }
+  ) {
+    this.mapManager = new MapChartManager(onError, {
+      syncStore: options?.syncStore ?? true,
+    });
   }
 
   /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -125,6 +125,23 @@ export interface ExpertBatch {
   total_cases: number;
 }
 
+export interface SpatialComparisonRegion {
+  value: string;
+  label: string;
+  scope?: "province" | "city";
+}
+
+export interface SpatialComparisonItem {
+  label: string;
+  count: number;
+  locations: MapLocation[];
+  filters: Record<string, unknown>;
+}
+
+export interface SpatialComparisonResponse {
+  comparisons: SpatialComparisonItem[];
+}
+
 export const TEMPERATURE_COLORS: Record<number, string> = {
   [-10]: "#0000FF", // 0, 0, 255
   [-9]: "#0019FF", // 0, 25, 255


### PR DESCRIPTION
This pull request completes PBI 14 for spatial comparison on the map page and hardens expert related token handling on the frontend. I add a new spatial comparison overlay on top of the main map so users can open a side by side comparison panel, pick up to two regions, and see synchronized maps and summary cards for each region. The panel uses the spatial comparison hook and a new API client method that posts regions and base filters to the backend, including API key and bearer token when available, and shows clear feedback for loading and error states. The map now supports separate map identifiers, toggleable chrome, and options to share or not share the Zustand store so that the split view can reuse the same chart logic without fighting over state. On the map page I also introduce an auto refresh button near the bottom left that opens a small configuration panel where users can enable periodic refresh, choose the refresh interval, and trigger a manual reload of location data, and the locations hook now respects a refresh token in its signature so that both auto and manual refresh are fully testable. On the expert flows I harden token discovery by checking multiple local storage keys and cookies, tighten the expert bulk upload and expert data management view tests so they mock auth in a consistent way, and update some dashboard copy and tooltip handling to be more robust in Bahasa and more defensive when custom tooltip text is missing.