### PR TITLE
[REFACTOR] Stabilize spatial comparison selections

### DIFF
--- a/app/components/spatial/SpatialComparisonPanel.tsx
+++ b/app/components/spatial/SpatialComparisonPanel.tsx
@@ -142,31 +142,36 @@ const ComparisonCard = ({
   );
 };
 
-export default function SpatialComparisonPanel({
-  baseFilters,
-  refreshToken,
-  onError,
-  provinceHumidityData,
-  provinceTemperatureData,
-  provincePrecipitationData,
-  provinceSeverityData,
-  initialRegions = [],
-  maxRegions,
-  overlayMode = false,
-  onClose,
-}: SpatialComparisonPanelProps) {
+export default function SpatialComparisonPanel(props: SpatialComparisonPanelProps) {
+  const {
+    baseFilters,
+    refreshToken,
+    onError,
+    provinceHumidityData,
+    provinceTemperatureData,
+    provincePrecipitationData,
+    provinceSeverityData,
+    initialRegions,
+    maxRegions,
+    overlayMode = false,
+    onClose,
+  } = props;
+  const normalizedInitialRegions = useMemo(
+    () => initialRegions ?? [],
+    [initialRegions]
+  );
   const [regionOptions, setRegionOptions] = useState<SpatialComparisonRegion[]>([]);
-  const [selectedRegions, setSelectedRegions] = useState<SpatialComparisonRegion[]>(initialRegions);
-  const [regionA, setRegionA] = useState<SpatialComparisonRegion | null>(initialRegions[0] || null);
-  const [regionB, setRegionB] = useState<SpatialComparisonRegion | null>(initialRegions[1] || null);
+  const [selectedRegions, setSelectedRegions] = useState<SpatialComparisonRegion[]>(normalizedInitialRegions);
+  const [regionA, setRegionA] = useState<SpatialComparisonRegion | null>(normalizedInitialRegions[0] || null);
+  const [regionB, setRegionB] = useState<SpatialComparisonRegion | null>(normalizedInitialRegions[1] || null);
   const [isLoadingFilters, setIsLoadingFilters] = useState(false);
   const [filtersError, setFiltersError] = useState<string | null>(null);
 
   useEffect(() => {
-    setSelectedRegions(initialRegions);
-    setRegionA(initialRegions[0] || null);
-    setRegionB(initialRegions[1] || null);
-  }, [initialRegions]);
+    setSelectedRegions(normalizedInitialRegions);
+    setRegionA(normalizedInitialRegions[0] || null);
+    setRegionB(normalizedInitialRegions[1] || null);
+  }, [normalizedInitialRegions]);
 
   const reconcileOption = (current: SpatialComparisonRegion | null) => {
     if (!current) return null;


### PR DESCRIPTION
This change improves the stability of spatial comparison selections by ensuring the component always uses a normalized and memoized version of the initial region list. Previously the panel used the raw initialRegions array, which caused uncontrolled re-renders and inconsistent selections when the parent component refreshed or returned new props. The updated version memoizes the region list, updates selectedRegions and the regionA and regionB slots in a predictable way, and removes duplicated logic. This makes the comparison panel behave consistently when users open or close the overlay, switch filters, or trigger automatic refreshes. The refactor only touches state handling and does not change any visual layout or API behavior.
