### PR TITLE
Sprint 4 curator revision

### DIFF
--- a/app/curator-data-management/page.tsx
+++ b/app/curator-data-management/page.tsx
@@ -269,7 +269,10 @@ export default function CuratorDataManagementPage() {
                     return (
                       <li key={r.data_id} className="hover:bg-gray-50">
                         <div className="grid grid-cols-[1fr_1.6fr_1.6fr_1.6fr_1fr] items-center text-sm sm:text-base">
-                          <div className="px-4 py-3 break-words">{r.data_id}</div>
+                        <div className="px-4 py-3 break-words">
+                          {r.data_id ? `${r.data_id.slice(0, 12)}...` : "-"}
+                        </div>
+
                           <div className="px-4 py-3">{r.title}</div>
                           <div className="px-4 py-3">
                             {when ? new Date(when).toLocaleString("id-ID") : "-"}

--- a/app/expert-data-management/page.tsx
+++ b/app/expert-data-management/page.tsx
@@ -296,9 +296,25 @@ export default function ExpertDataManagementPage({
                   const isDel = deletingId === r.data_id;
                   return (
                     <tr key={r.data_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3">{r.data_id}</td>
+                      <td
+                        className="px-4 py-3"
+                        title={r.data_id} // tooltip shows full ID
+                      >
+                        {r.data_id ? `${r.data_id.slice(0, 10)}...` : "-"}
+                      </td>
                       <td className="px-4 py-3">{r.file_name}</td>
-                      <td className="px-4 py-3 whitespace-nowrap">{r.last_edited}</td>
+                      <td className="px-4 py-3 whitespace-nowrap">
+                        {r.last_edited
+                          ? new Date(r.last_edited).toLocaleString("id-ID", {
+                              day: "2-digit",
+                              month: "2-digit",
+                              year: "numeric",
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            })
+                          : "-"}
+                      </td>
                       <td className="px-4 py-3">{r.submitted_by}</td>
                       <td className="px-4 py-3 text-center">
                         <div className="flex justify-center gap-2">


### PR DESCRIPTION
app/curator-data-management/page.tsx
- Truncate displayed data_id to the first 12 characters followed by "..." (renders "-" when id is missing).

app/expert-data-management/page.tsx
- Add a title attribute to the ID cell so the full data_id appears as a tooltip.
- Truncate displayed data_id to the first 10 characters followed by "..." (renders "-" when id is missing).
- Format r.last_edited using new Date(r.last_edited).toLocaleString("id-ID", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" }) and fall back to "-" if empty.